### PR TITLE
Add option to disable email cheking for imported CSV

### DIFF
--- a/lib/models/subscriptions.js
+++ b/lib/models/subscriptions.js
@@ -982,7 +982,7 @@ module.exports.delete = (listId, cid, callback) => {
     });
 };
 
-module.exports.createImport = (listId, type, path, size, delimiter, mapping, callback) => {
+module.exports.createImport = (listId, type, path, size, delimiter, emailcheck, mapping, callback) => {
     listId = Number(listId) || 0;
     type = Number(type) || 1;
 
@@ -994,8 +994,8 @@ module.exports.createImport = (listId, type, path, size, delimiter, mapping, cal
         if (err) {
             return callback(err);
         }
-        let query = 'INSERT INTO importer (`list`, `type`, `path`, `size`, `delimiter`, `mapping`) VALUES(?,?,?,?,?,?)';
-        connection.query(query, [listId, type, path, size, delimiter, JSON.stringify(mapping)], (err, result) => {
+        let query = 'INSERT INTO importer (`list`, `type`, `path`, `size`, `delimiter`, `emailcheck`, `mapping`) VALUES(?,?,?,?,?,?,?)';
+        connection.query(query, [listId, type, path, size, delimiter, emailcheck,  JSON.stringify(mapping)], (err, result) => {
             connection.release();
             if (err) {
                 return callback(err);

--- a/meta.json
+++ b/meta.json
@@ -1,3 +1,3 @@
 {
-    "schemaVersion": 23
+    "schemaVersion": 24
 }

--- a/routes/lists.js
+++ b/routes/lists.js
@@ -555,7 +555,7 @@ router.post('/subscription/import', uploads.single('listimport'), passport.parse
                 return res.redirect('/lists');
             } else {
 
-                subscriptions.createImport(list.id, req.body.type === 'subscribed' ? 1 : 2, req.file.path, req.file.size, delimiter, {
+                subscriptions.createImport(list.id, req.body.type === 'subscribed' ? 1 : 2, req.file.path, req.file.size, delimiter, req.body.emailcheck === 'enabled' ? 1 : 0, {
                     columns: rows[0],
                     example: rows[1] || []
                 }, (err, importId) => {

--- a/setup/sql/upgrade-00024.sql
+++ b/setup/sql/upgrade-00024.sql
@@ -1,0 +1,11 @@
+# Header section
+# Define incrementing schema version number
+SET @schema_version = '24';
+
+# Add field 
+ALTER TABLE `importer` ADD COLUMN `emailcheck` tinyint(4) unsigned DEFAULT 1 NOT NULL AFTER `delimiter`;
+
+# Footer section
+LOCK TABLES `settings` WRITE;
+INSERT INTO `settings` (`key`, `value`) VALUES('db_schema_version', @schema_version) ON DUPLICATE KEY UPDATE `value`=@schema_version;
+UNLOCK TABLES;

--- a/views/lists/subscription/import.hbs
+++ b/views/lists/subscription/import.hbs
@@ -43,6 +43,22 @@
         </div>
     </div>
 
+    <div class="form-group">
+        <label class="col-sm-2 control-label">{{#translate}}Check imported emails{{/translate}}:</label>
+        <div class="col-sm-6">
+            <div class="radio">
+                <label>
+                    <input type="radio" name="emailcheck" id="type" value="enabled" checked> {{#translate}}Enabled{{/translate}}
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="emailcheck" id="type" value="disabled"> {{#translate}}Disabled{{/translate}}
+                </label>
+            </div>
+        </div>
+    </div>
+
     <hr />
 
     <div class="form-group">


### PR DESCRIPTION
Hello. This request add option, that can disable email checking for emails, imported from CSV file. This option useful for speedup import big csv (1+ million rows) files.
[Screenshot](https://ibb.co/hOoo8v)