### PR TITLE
Docker changes for using local files rather than pulling from web

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos
 RUN curl --silent --location https://rpm.nodesource.com/setup_7.x | bash -
 RUN yum install -y git make gcc nodejs ImageMagick && yum clean all
-RUN git clone git://github.com/Mailtrain-org/mailtrain.git /app
+COPY . /app
 WORKDIR /app/
 ENV NODE_ENV production
 RUN npm install --no-progress --production && npm install --no-progress passport-ldapjs


### PR DESCRIPTION
Using the local files for the docker build rather than performing a git clone. This way if we build from an older release, we will be building that release rather than always the latest version of mailtrain.

This pull request is a one line change that does not require moving any files around.

Refer to the discussion [here](https://github.com/Mailtrain-org/mailtrain/issues/194).