### PR TITLE
RSS Improvements to allow more template tags

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -50,7 +50,9 @@ module.exports.fetch = (url, callback) => {
                 date: item.date || item.pubdate || item.pubDate || new Date(),
                 guid: item.guid || item.link,
                 link: item.link,
-                content: item.description || item.summary
+                content: item.description || item.summary,
+                summary: item.summary || item.description,
+                image_url: item.image.url,
             };
             entries.push(entry);
         }

--- a/services/feedcheck.js
+++ b/services/feedcheck.js
@@ -132,8 +132,11 @@ function checkEntries(parent, entries, callback) {
                 let entryId = result.insertId;
                 let html = (parent.html || '').toString().trim();
 
-                if (/\[RSS_ENTRY\]/i.test(html)) {
-                    html = html.replace(/\[RSS_ENTRY\]/, entry.content);
+                if (/\[RSS_ENTRY[\w]*\]/i.test(html)) {
+                    html = html.replace(/\[RSS_ENTRY\]/, entry.content); //for backward compatibility
+                    Object.keys(entry).forEach(key => {
+                        html = html.replace('\[RSS_ENTRY_'+key.toUpperCase()+'\]', entry[key])
+                    });
                 } else {
                     html = entry.content + html;
                 }


### PR DESCRIPTION
Changes to allow more template tags in RSS Campaings. Allowed tags are ([RSS_ENTRY_TITLE], [RSS_ENTRY_DATE], [RSS_ENTRY_LINK], [RSS_ENTRY_CONTENT], [RSS_ENTRY_SUMMARY], [RSS_ENTRY_IMAGE_URL])