### PR TITLE
Basic Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+dist: trusty
+sudo: required
+language: node_js
+node_js:
+  - 7
+services:
+  - mysql
+before_install:
+  - sudo apt-get -q -y install pwgen imagemagick
+install:
+  - sudo bash test/e2e/install.sh
+  - npm install
+before_script:
+  - npm run starttest > /dev/null 2>&1 &
+  - sleep 10
+script:
+  - grunt
+  - npm run _e2e


### PR DESCRIPTION
This PR adds basic integration with [Travis CI](https://travis-ci.com), which is "always free for open source projects". It runs `grunt` and `e2e` tests for every commit and PR (depending on setup), and adds a nice little status message: 

![travis-commit-status](https://cloud.githubusercontent.com/assets/4999980/26532919/7c6aa3e4-440e-11e7-9b74-478e3afbfde1.png)

Clicking the checkmark [takes you to the logs of that test](https://travis-ci.org/witzig/mailtrain/builds/236999300?utm_source=github_status&utm_medium=notification).

@andris9, if this gets merged, you would need to connect Mailtrain-org with Travis and flick some switches. It's a 5 minute job.
