### PR TITLE
Fix typo during refactoring

### DIFF
--- a/lib/models/subscriptions.js
+++ b/lib/models/subscriptions.js
@@ -495,7 +495,7 @@ module.exports.changeStatus = (listId, id, campaignId, status, callback) => {
                         }
 
                         // status change is not related to a campaign or it marks message as bounced etc.
-                        if (!campaignId || status > Status.UNSUBSCRIBED) {
+                        if (!campaignId || status !== Status.SUBSCRIBED && status !== Status.UNSUBSCRIBED) {
                             return connection.commit(err => {
                                 if (err) {
                                     return helpers.rollbackAndReleaseConnection(connection, () => callback(err));

--- a/lib/models/subscriptions.js
+++ b/lib/models/subscriptions.js
@@ -495,7 +495,7 @@ module.exports.changeStatus = (listId, id, campaignId, status, callback) => {
                         }
 
                         // status change is not related to a campaign or it marks message as bounced etc.
-                        if (!campaignId || status !== Status.SUBSCRIBED) {
+                        if (!campaignId || status > Status.UNSUBSCRIBED) {
                             return connection.commit(err => {
                                 if (err) {
                                     return helpers.rollbackAndReleaseConnection(connection, () => callback(err));


### PR DESCRIPTION
During code refactoring for selectable
unsubscription feature code:
`!campaignId || status > 2` was wrongly refactored
to:
`!campaignId || status !== Status.SUBSCRIBED`

Should be:
`!campaignId || status > Status.UNSUBSCRIBED`

Link:
https://github.com/Mailtrain-org/mailtrain/commit/a6d25e668b6d9a31b90b05bb9bfe7d65f1d619a1#diff-5af9fe5dfae76c093530c92e3d7404e1R496