### PR TITLE
Check for locally requeued messages in postfix

### DIFF
--- a/lib/models/campaigns.js
+++ b/lib/models/campaigns.js
@@ -1086,6 +1086,24 @@ module.exports.updateMessage = (message, status, updateSubscription, callback) =
     });
 };
 
+module.exports.updateMessageResponse = (message, response, response_id, callback) => {
+    db.getConnection((err, connection) => {
+        if (err) {
+            return callback(err);
+        }
+
+        let query = 'UPDATE `campaign__' + message.campaign + '` SET `response`=?, `response_id`=? WHERE id=? LIMIT 1';
+        connection.query(query, [response, response_id, message.id], err => {
+            connection.release();
+            if (err) {
+                return callback(err);
+            }
+            return callback(null, true);
+        });
+
+    });
+};
+
 function createCampaignTables(id, callback) {
     let query = 'CREATE TABLE `campaign__' + id + '` LIKE campaign';
     db.getConnection((err, connection) => {

--- a/services/postfix-bounce-server.js
+++ b/services/postfix-bounce-server.js
@@ -41,18 +41,16 @@ let server = net.createServer(socket => {
                 // Losacno: Check for local requeue
                 let status = match[2];
                 log.verbose('POSTFIXBOUNCE', 'Checking message %s for local requeue (status: %s)', queueId, status);
-                if ( status == 'sent' ) {
+                if ( status === 'sent' ) {
                     let queued = / relay=127\.0\.0\.1/.test(line) && line.match(/ queued as (\w+)\)/);
                     if ( queued ) {
                         log.verbose('POSTFIXBOUNCE', 'Marked message %s as locally requeued as %s', queueId, queued[1]);
                         queueIds[queued[1]] = queueId;
                     }
                     return checkNextLine();
-                } else {
-                    if ( queueId in queueIds ) {
-                        log.verbose('POSTFIXBOUNCE', 'Message %s was requeued from %s', queueId, queueIds[queueId]);
-                        queueId = queueIds[queueId];
-                    }
+                } else if ( queueId in queueIds ) {
+                    log.verbose('POSTFIXBOUNCE', 'Message %s was requeued from %s', queueId, queueIds[queueId]);
+                    queueId = queueIds[queueId];
                 }
 
                 campaigns.findMailByResponse(queueId, (err, message) => {

--- a/services/postfix-bounce-server.js
+++ b/services/postfix-bounce-server.js
@@ -44,7 +44,7 @@ let server = net.createServer(socket => {
                 log.verbose('POSTFIXBOUNCE', 'Checking message %s for local requeue (status: %s)', queueId, status);
                 if ( status === 'sent' ) {
                     // Save new queueId to update message's previous queueId (thanks @mfechner )
-                    queued = / relay=127\.0\.0\.1/.test(line) && line.match(/status=sent \((.*)\)/);
+                    queued = / relay=/.test(line) && line.match(/status=sent \((.*)\)/);
                     if ( queued ) {
                         queued = queued[1];
                         queued_as = queued.match(/ queued as (\w+)/);

--- a/services/postfix-bounce-server.js
+++ b/services/postfix-bounce-server.js
@@ -6,7 +6,6 @@ let net = require('net');
 let campaigns = require('../lib/models/campaigns');
 
 let seenIds = new Set();
-let queueIds = {};
 
 let server = net.createServer(socket => {
     let remainder = '';
@@ -32,6 +31,8 @@ let server = net.createServer(socket => {
             let match = /\bstatus=(bounced|sent)\b/.test(line) && line.match(/\bpostfix\/\w+\[\d+\]:\s*([^:]+).*?status=(\w+)/);
             if (match) {
                 let queueId = match[1];
+                let queued = '';
+                let queued_as = '';
 
                 if (seenIds.has(queueId)) {
                     return checkNextLine();
@@ -42,28 +43,42 @@ let server = net.createServer(socket => {
                 let status = match[2];
                 log.verbose('POSTFIXBOUNCE', 'Checking message %s for local requeue (status: %s)', queueId, status);
                 if ( status === 'sent' ) {
-                    let queued = / relay=127\.0\.0\.1/.test(line) && line.match(/ queued as (\w+)\)/);
-                    if ( queued ) {
-                        log.verbose('POSTFIXBOUNCE', 'Marked message %s as locally requeued as %s', queueId, queued[1]);
-                        queueIds[queued[1]] = queueId;
+                    // Save new queueId to update message's previous queueId (thanks @mfechner )
+                    if ( queued = / relay=127\.0\.0\.1/.test(line) && line.match(/status=sent \((.*)\)/) ) {
+                        queued = queued[1];
+                        queued_as = queued.match(/ queued as (\w+)/);
+                        queued_as = queued_as[1];
                     }
-                    return checkNextLine();
-                } else if ( queueId in queueIds ) {
-                    log.verbose('POSTFIXBOUNCE', 'Message %s was requeued from %s', queueId, queueIds[queueId]);
-                    queueId = queueIds[queueId];
                 }
 
                 campaigns.findMailByResponse(queueId, (err, message) => {
                     if (err || !message) {
                         return checkNextLine();
                     }
-                    campaigns.updateMessage(message, 'bounced', true, (err, updated) => {
-                        if (err) {
-                            log.error('POSTFIXBOUNCE', 'Failed updating message: %s', err && err.stack);
-                        } else if (updated) {
-                            log.verbose('POSTFIXBOUNCE', 'Marked message %s as bounced', queueId);
-                        }
-                    });
+                    if ( queued_as ) {
+                        log.verbose('POSTFIXBOUNCE', 'Message %s locally requeued as %s', queueId, queued_as);
+                        // Update message's previous queueId (thanks @mfechner )
+                        campaigns.updateMessageResponse(message, queued, queued_as, (err, updated) => {
+                            if (err) {
+                                log.error('POSTFIXBOUNCE', 'Failed updating message: %s', err && err.stack);
+                            } else if (updated) {
+                                log.verbose('POSTFIXBOUNCE', 'Successfully changed message queueId to %s', queued_as);
+                            }
+                        });
+
+                    } else {
+                        campaigns.updateMessage(message, 'bounced', true, (err, updated) => {
+                            if (err) {
+                                log.error('POSTFIXBOUNCE', 'Failed updating message: %s', err && err.stack);
+                            } else if (updated) {
+                                log.verbose('POSTFIXBOUNCE', 'Marked message %s as bounced', queueId);
+                            }
+                        });
+                    }
+
+                    // No need to keep in memory... free it ( thanks @witzig )
+                    seenIds.delete(queueId);
+
                     return checkNextLine();
                 });
                 return;

--- a/services/postfix-bounce-server.js
+++ b/services/postfix-bounce-server.js
@@ -44,7 +44,8 @@ let server = net.createServer(socket => {
                 log.verbose('POSTFIXBOUNCE', 'Checking message %s for local requeue (status: %s)', queueId, status);
                 if ( status === 'sent' ) {
                     // Save new queueId to update message's previous queueId (thanks @mfechner )
-                    if ( queued = / relay=127\.0\.0\.1/.test(line) && line.match(/status=sent \((.*)\)/) ) {
+                    queued = / relay=127\.0\.0\.1/.test(line) && line.match(/status=sent \((.*)\)/);
+                    if ( queued ) {
                         queued = queued[1];
                         queued_as = queued.match(/ queued as (\w+)/);
                         queued_as = queued_as[1];


### PR DESCRIPTION
When using Postfix + Amavis received mail first goes to Amavisd and, if not spam, is queued to Postfix Smtp service so queue id for bounce check is not the first one but the second as you can see:

    Jun 27 14:30:11 server-mx postfix/smtpd[8270]: connect from localhost[127.0.0.1]
    Jun 27 14:30:11 server-mx postfix/smtpd[8270]: NOQUEUE: filter: RCPT from localhost[127.0.0.1]: <mail@sender.tld>: Sender address triggers FILTER amavis:[127.0.0.1]:10026; from=<mail@sender.tld> to=<mail@receiver.tld> proto=ESMTP helo=<[127.0.0.1]>
    Jun 27 14:30:11 server-mx postfix/smtpd[8270]: B2BBE8414B5: client=localhost[127.0.0.1], sasl_method=PLAIN, sasl_username=mail@sender.tld
    Jun 27 14:30:11 server-mx postfix/cleanup[8313]: B2BBE8414B5: message-id=<mail-id@sender.tld>
    Jun 27 14:30:11 server-mx postfix/qmgr[1694]: B2BBE8414B5: from=<mail@sender.tld>, size=123137, nrcpt=1 (queue active)
    Jun 27 14:30:12 server-mx postfix/smtpd[8318]: connect from localhost[127.0.0.1]
    Jun 27 14:30:12 server-mx postfix/smtpd[8318]: C642C8414CE: client=localhost[127.0.0.1]
    Jun 27 14:30:12 server-mx postfix/cleanup[8313]: C642C8414CE: message-id=<mail-id@sender.tld>
    Jun 27 14:30:12 server-mx postfix/smtpd[8318]: disconnect from localhost[127.0.0.1]
    Jun 27 14:30:12 server-mx postfix/qmgr[1694]: C642C8414CE: from=<mail@sender.tld>, size=124068, nrcpt=1 (queue active)
    Jun 27 14:30:12 server-mx amavis[5085]: (05085-15) Passed CLEAN {RelayedOutbound}, ORIGINATING LOCAL [127.0.0.1]:45421 <mail@sender.tld> -> <mail@receiver.tld>, Queue-ID: B2BBE8414B5, Message-ID: <mail-id@sender.tld>, mail_id: KFebp5elSvWC, Hits: -0.997, size: 123137, queued_as: C642C8414CE, dkim_new=dkim:sender.tld, 1048 ms
    Jun 27 14:30:12 server-mx postfix/smtp[8314]: B2BBE8414B5: to=<mail@receiver.tld>, relay=127.0.0.1[127.0.0.1]:10026, delay=1.2, delays=0.11/0.01/0/1.1, dsn=2.0.0, status=sent (250 2.0.0 from MTA(smtp:[127.0.0.1]:10027): 250 2.0.0 Ok: queued as C642C8414CE)
    Jun 27 14:30:12 server-mx postfix/qmgr[1694]: B2BBE8414B5: removed
    Jun 27 14:30:15 server-mx postfix/smtp[8320]: C642C8414CE: to=<mail@receiver.tld>, relay=remote-mx.tld[2.2.2.2]:25, delay=2.5, delays=0.07/0.01/2.1/0.26, dsn=5.7.1, status=bounced (host remote-mx.tld[2.2.2.2] said: 550 5.7.1 <mail@receiver.tld>: Recipient address rejected: User unknown. (in reply to RCPT TO command))
    Jun 27 14:30:15 server-mx postfix/cleanup[8313]: 6DE8F841563: message-id=<new-mail-id@server.sender.tld>
    Jun 27 14:30:15 server-mx postfix/bounce[8324]:C642C8414CE: sender non-delivery notification: 6DE8F841563

This PR try to solve this problem saving locally requeued messages in an array and checking bounces against it