### PR TITLE
Fixed an issue where API dates were not correctly being triggered.

### DIFF
--- a/lib/models/triggers.js
+++ b/lib/models/triggers.js
@@ -98,7 +98,10 @@ module.exports.getQuery = (id, callback) => {
         }
 
         let limit = 300;
-        let treshold = 3600 * 6; // time..NOW..time+6h, 6 hour window after trigger target to detect it
+
+        // time..NOW..time + 24h, 24 hour window after trigger target to detect it
+        //We need a 24 hour window for triggers as the format for dates added via the API are stored as 00:00:00
+        let treshold = 3600 * 24;
 
         let intervalQuery = (column, seconds, treshold) => column + ' <= NOW() - INTERVAL ' + seconds + ' SECOND AND ' + column + ' >= NOW() - INTERVAL ' + (treshold + seconds) + ' SECOND';
 


### PR DESCRIPTION
Changed the trigger `treshold` value from 6 hours to 24 hours, so that dates stored via the API as 00:00:00 are correctly picked up and added to the queue.