### PR TITLE
Fix docker install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ With proper SPF, DKIM and PTR records (DMARC wouldn't hurt either) I got perfect
 
 * Download Mailtrain files using git: `git clone git://github.com/Mailtrain-org/mailtrain.git` (or download [zipped repo](https://github.com/Mailtrain-org/mailtrain/archive/master.zip)) and open Mailtrain folder `cd mailtrain`
 * **Note**: depending on how you have configured your system and Docker you may need to prepend the commands below with `sudo`.
-* Copy the file `docker-compose.override.yml.tmpl` to `docker-compose.override.yml.tmpl` and modify it if you need to.
+* Copy the file `docker-compose.override.yml.tmpl` to `docker-compose.override.yml` and modify it if you need to.
 * Bring up the stack with: `docker-compose up -d`, by default it will use the included `docker-compose.yml` file and override some configurations taken from the `docker-compose.override.yml` file.
 * If you want to use only / copy the `docker-compose.yml` file (for example, if you were deploying with Rancher), you may need to first run `docker-compose build` to make sure your system has a Docker image `mailtrain:latest`.
 * Open [http://localhost:3000/](http://localhost:3000/) (change the host name `localhost` to the name of the host where you are deploying the system).


### PR DESCRIPTION
I just tried to install Mailtrain using Docker.
I suppose this line from the install instructions contains an error:

> Copy the file docker-compose.override.yml.tmpl to docker-compose.override.yml.tmpl and modify it if you need to.

I suppose the destination filename should not contain the `.tmpl` ending. Is that correct? If so, I changed it accordingly.

`Change extension name of copied docker-compose-override file to not be the same as source`