### PR TITLE
add package-lock.json file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 node_modules
 npm-debug.log
+package-lock.json
 .DS_Store
 config/development.*
 config/production.*


### PR DESCRIPTION
Since node 8, package-lock.json is automatically generated.