### PR TITLE
Bumping the dockerfile baseimage from node 8.1 to 8.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.1
+FROM node:8.6
 
 # First install dependencies
 COPY ./package.json ./app/


### PR DESCRIPTION
Bumping the dockerfile baseimage from node 8.1 to 8.6 [as per issue 288](https://github.com/Mailtrain-org/mailtrain/issues/288).