### PR TITLE
Add option to preserve unsubscribed status on list import

### DIFF
--- a/lib/models/subscriptions.js
+++ b/lib/models/subscriptions.js
@@ -625,7 +625,7 @@ module.exports.delete = (listId, cid, callback) => {
 
 module.exports.createImport = (listId, type, path, size, delimiter, emailcheck, mapping, callback) => {
     listId = Number(listId) || 0;
-    type = Number(type) || 1;
+    type = Number(type) || 0;
 
     if (listId < 1) {
         return callback(new Error('Missing List ID'));

--- a/lib/models/subscriptions.js
+++ b/lib/models/subscriptions.js
@@ -162,6 +162,9 @@ module.exports.insert = (listId, meta, subscriptionData, callback) => {
                     let entryId = existing ? existing.id : false;
 
                     meta.cid = existing ? rows[0].cid : meta.cid;
+
+                    // meta.status may be 'undefined' or '0' when adding a subscription via API call or CSV import. In both cases meta.partial is 'true'.
+                    // This must either update an existing subscription without changing its status or insert a new subscription with status SUBSCRIBED.
                     meta.status = meta.status || (existing ? existing.status : Status.SUBSCRIBED);
 
                     let statusChange = !existing || existing.status !== meta.status;

--- a/routes/lists.js
+++ b/routes/lists.js
@@ -574,7 +574,14 @@ router.post('/subscription/import', uploads.single('listimport'), passport.parse
                 return res.redirect('/lists');
             } else {
 
-                subscriptions.createImport(list.id, req.body.type === 'subscribed' ? 1 : 2, req.file.path, req.file.size, delimiter, req.body.emailcheck === 'enabled' ? 1 : 0, {
+                let type = 0; // Use the existing subscription status or SUBSCRIBED
+                if (req.body.type === 'force_subscribed') {
+                    type = subscriptions.Status.SUBSCRIBED;
+                } else if (req.body.type === 'unsubscribed') {
+                    type = subscriptions.Status.UNSUBSCRIBED;
+                }
+
+                subscriptions.createImport(list.id, type, req.file.path, req.file.size, delimiter, req.body.emailcheck === 'enabled' ? 1 : 0, {
                     columns: rows[0],
                     example: rows[1] || []
                 }, (err, importId) => {

--- a/routes/lists.js
+++ b/routes/lists.js
@@ -285,7 +285,7 @@ router.get('/view/:id', passport.csrfProtection, (req, res) => {
 
                 list.imports = imports.map((entry, i) => {
                     entry.index = i + 1;
-                    entry.importType = entry.type === 1 ? _('Subscribe') : _('Unsubscribe');
+                    entry.importType = entry.type === 0 ? _('Force Subscribe') : (entry.type === 1 ? _('Subscribe') : _('Unsubscribe'));
                     switch (entry.status) {
                         case 0:
                             entry.importStatus = _('Initializing');

--- a/views/lists/subscription/import.hbs
+++ b/views/lists/subscription/import.hbs
@@ -37,6 +37,11 @@
             </div>
             <div class="radio">
                 <label>
+                    <input type="radio" name="type" id="type" value="force_subscribed"> {{#translate}}Subscribed (Force){{/translate}} – <span class="text-muted">{{#translate}}Regular subscriber addresses, resubscribe users that have unsubscribed{{/translate}}</span>
+                </label>
+            </div>
+            <div class="radio">
+                <label>
                     <input type="radio" name="type" id="type" value="unsubscribed"> {{#translate}}Unsubscribed{{/translate}} – <span class="text-muted">{{#translate}}Suppressed emails that will be unsubscribed from your list{{/translate}}</span>
                 </label>
             </div>

--- a/views/lists/subscription/import.hbs
+++ b/views/lists/subscription/import.hbs
@@ -29,7 +29,7 @@
 
     <div class="form-group">
         <label class="col-sm-2 control-label">{{#translate}}Categorize the imported subscribers as{{/translate}}:</label>
-        <div class="col-sm-6">
+        <div class="col-sm-10">
             <div class="radio">
                 <label>
                     <input type="radio" name="type" id="type" value="subscribed" checked> {{#translate}}Subscribed{{/translate}} – <span class="text-muted">{{#translate}}Regular subscriber addresses{{/translate}}</span>


### PR DESCRIPTION
References issue #325

Tomas, can you review this please? Using `0` as the subscription status leaves the status of an existing subscription unchanged or defaults to `SUBSCRIBED` for new users. See [here](https://github.com/Mailtrain-org/mailtrain/blob/4f5c132db4bca35e0fb310ce1c03da73cd9e9170/lib/models/subscriptions.js#L165): 

```
meta.status = meta.status || (existing ? existing.status : Status.SUBSCRIBED);
```

It feels a bit like cheating to me. :)

- - -

![screenshot](https://user-images.githubusercontent.com/4999980/30941979-6e2ec1f4-a3e8-11e7-8609-6be5d804ef85.png)