### PR TITLE
add: LDAP options `bindUser` and `bindPassword`

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -121,6 +121,9 @@ filter="(|(username={{username}})(mail={{username}}))"
 #Username field in LDAP (uid/cn/username)
 uidTag="username"
 passwordresetlink=""
+# Use a different user to bind LDAP (final bind DN will be: {{uidTag}}={{bindUser}},{{baseDN}})
+bindUser=""
+bindPassword=""
 
 [postfixbounce]
 # Enable to allow writing Postfix bounce log to Mailtrain listener

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -85,7 +85,9 @@ if (config.ldap.enabled && LdapStrategy) {
             attributes: [config.ldap.uidTag, 'mail'],
             scope: 'sub'
         },
-        uidTag: config.ldap.uidTag
+        uidTag: config.ldap.uidTag,
+        bindUser: config.ldap.bindUser,
+        bindPassword: config.ldap.bindPassword
     };
 
     passport.use(new LdapStrategy(opts, (profile, done) => {


### PR DESCRIPTION
To be able to use a different user for bind requests,
which can be required by some LDAP security strategy.

Linked to issue #340 