### PR TITLE
Adds duplicate Template

### DIFF
--- a/lib/models/templates.js
+++ b/lib/models/templates.js
@@ -61,15 +61,17 @@ module.exports.create = (template, callback) => {
     let values = [name];
 
     Object.keys(template).forEach(key => {
-        let value = template[key].trim();
+        let value = template[key];
         key = tools.toDbKey(key);
+        if (!allowedKeys.includes(key)) {
+            return;
+        }
+        value = value.trim();
         if (key === 'description') {
             value = tools.purifyHTML(value);
         }
-        if (allowedKeys.indexOf(key) >= 0) {
-            keys.push(key);
-            values.push(value);
-        }
+        keys.push(key);
+        values.push(value);
     });
 
     db.getConnection((err, connection) => {
@@ -136,6 +138,16 @@ module.exports.update = (id, updates, callback) => {
         });
     });
 };
+
+module.exports.duplicate = (id, callback) => {
+    return this.get(id, (err, template) => {
+        if (!template) {
+            return callback(new Error(_('Template does not exist')));
+        }
+        template.name = template.name + ' Copy';
+        return this.create(template, callback);
+    });
+}
 
 module.exports.delete = (id, callback) => {
     id = Number(id) || 0;

--- a/lib/models/templates.js
+++ b/lib/models/templates.js
@@ -139,15 +139,16 @@ module.exports.update = (id, updates, callback) => {
     });
 };
 
-module.exports.duplicate = (id, callback) => {
-    return this.get(id, (err, template) => {
-        if (!template) {
-            return callback(new Error(_('Template does not exist')));
-        }
-        template.name = template.name + ' Copy';
-        return this.create(template, callback);
-    });
-}
+module.exports.duplicate = (id, callback) => module.exports.get(id, (err, template) => {
+    if (err) {
+        return callback(err);
+    }
+    if (!template) {
+        return callback(new Error(_('Template does not exist')));
+    }
+    template.name = template.name + ' Copy';
+    return module.exports.create(template, callback);
+});
 
 module.exports.delete = (id, callback) => {
     id = Number(id) || 0;

--- a/routes/templates.js
+++ b/routes/templates.js
@@ -136,6 +136,19 @@ router.post('/edit', passport.parseForm, passport.csrfProtection, (req, res) => 
     });
 });
 
+router.post('/duplicate', passport.parseForm, passport.csrfProtection, (req, res) => {
+    templates.duplicate(req.body.id, (err, duplicated) => {
+        if (err) {
+            req.flash('danger', err && err.message || err);
+        } else if (duplicated) {
+            req.flash('success', _('Template duplicated'));
+        } else {
+            req.flash('info', _('Could not duplicate specified template'));
+        }
+        return res.redirect('/templates/edit/' + duplicated);
+    });
+});
+
 router.post('/delete', passport.parseForm, passport.csrfProtection, (req, res) => {
     templates.delete(req.body.id, (err, deleted) => {
         if (err) {

--- a/views/templates/edit.hbs
+++ b/views/templates/edit.hbs
@@ -13,6 +13,11 @@
     <input type="hidden" name="id" value="{{id}}" />
 </form>
 
+<form method="post" class="duplicate-form" id="templates-duplicate" action="/templates/duplicate">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
+    <input type="hidden" name="id" value="{{id}}" />
+</form>
+
 <form class="form-horizontal" method="post" action="/templates/edit">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <input type="hidden" name="id" value="{{id}}" />
@@ -45,6 +50,7 @@
     <div class="form-group">
         <div class="col-sm-offset-2 col-sm-10">
             <div class="pull-right">
+                <button type="submit" form="templates-duplicate" class="btn btn-default"> {{#translate}}Duplicate{{/translate}}</button>
                 <button type="submit" form="templates-delete" class="btn btn-danger"><i class="glyphicon glyphicon-remove"></i> {{#translate}}Delete Template{{/translate}}</button>
             </div>
             <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i> {{#translate}}Update{{/translate}}</button>


### PR DESCRIPTION
This adds a duplicate button the edit template page. Pressing this button gets the template by id and creates a new template with retrieved data, appending "Copy" to the template name and redirecting the user to the edit page for the new template.

For issue #247 