### PR TITLE
Add API support for GET /api/subscriptions/:listId

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -315,6 +315,39 @@ router.post('/delete/:listId', (req, res) => {
     });
 });
 
+router.get('/subscriptions/:listId', (req, res) => {
+    let start = parseInt(req.query.start || 0, 10);
+    let limit = parseInt(req.query.limit || 10000, 10);
+
+    lists.getByCid(req.params.listId, (err, list) => {
+	if (err) {
+            res.status(500);
+            return res.json({
+		error: err.message || err,
+		data: []
+            });
+	}
+	subscriptions.list(list.id, start, limit, (err, rows, total) => {
+	    if (err) {
+		res.status(500);
+		return res.json({
+		    error: err.message || err,
+		    data: []
+		});
+	    }
+	    res.status(200);
+	    res.json({
+		data: {
+		    total: total,
+		    start: start,
+		    limit: limit,
+		    subscriptions: rows
+		}
+	    });
+	});
+    });
+});
+
 router.post('/field/:listId', (req, res) => {
     let input = {};
     Object.keys(req.body).forEach(key => {

--- a/views/users/api.hbs
+++ b/views/users/api.hbs
@@ -46,7 +46,7 @@
 <h3>GET /api/subscriptions/:listId – {{#translate}}Get list of subscriptions{{/translate}}</h3>
 
 <p>
-    {{#translate}}Retrieve a list of subscriptions to the list referenced by :listId. All fields of the subscribers will be returned.{{/translate}}
+    {{#translate}}Retrieve a list of subscriptions to the list referenced by :listId. All fields of the subscribers will be returned. Note that custom fields will have generated names.{{/translate}}
 </p>
 
 <p>

--- a/views/users/api.hbs
+++ b/views/users/api.hbs
@@ -43,6 +43,27 @@
     </ul>
 </div>
 
+<h3>GET /api/subscriptions/:listId – {{#translate}}Get list of subscriptions{{/translate}}</h3>
+
+<p>
+    {{#translate}}Retrieve a list of subscriptions to the list referenced by :listId. All fields of the subscribers will be returned.{{/translate}}
+</p>
+
+<p>
+    <strong>GET</strong> {{#translate}}arguments{{/translate}}
+</p>
+<ul>
+    <li><strong>access_token</strong> – {{#translate}}your personal access token{{/translate}}
+    <li><strong>start</strong> – {{#translate}}Start position{{/translate}} (<em>{{#translate}}optional, default 0{{/translate}}</em>)</li>
+    <li><strong>limit</strong> – {{#translate}}limit subscription count in response{{/translate}} (<em>{{#translate}}optional, default 10000{{/translate}}</em>)</li>
+</ul>
+
+<p>
+    <strong>{{#translate}}Example{{/translate}}</strong>
+</p>
+
+<pre>curl -XGET '{{serviceUrl}}api/subscriptions/B16uVTdW?access_token={{accessToken}}&limit=10&start=0' </pre>
+
 <h3>POST /api/subscribe/:listId – {{#translate}}Add subscription{{/translate}}</h3>
 
 <p>


### PR DESCRIPTION
I needed a way to retrieve all subscriptions to a list, in order to synchronize mailtrain with our own administration. I'm not that happy with the fact custom fields get weird generated names in the JSON, but in practice it's not a problem as those are easily copy-pasted into any code that uses them.