### PR TITLE
Add support for passport-ldapauth

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -125,6 +125,22 @@ passwordresetlink=""
 bindUser=""
 bindPassword=""
 
+[ldapauth]
+# Alternative LDAP implementation using the more popular passport-ldapauth library.
+enabled=false
+host="localhost"
+port=389
+# Subtree in which the searchrequest for the user is done
+baseDN="ou=users,dc=company"
+# What whe are searching for. This should return a single user.
+filter="(|(sAMAccountName={{username}})(mail={{username}}))"
+# Username field in LDAP, used to identify the user in Mailtrain (uid/cn/username/sAMAccountName)
+uidTag="sAMAccountName"
+passwordresetlink=""
+# Credentials for the initial search operation (final bind DN will be exactly as specified)
+bindUser="name@company.net"
+bindPassword="mySecretPassword"
+
 [postfixbounce]
 # Enable to allow writing Postfix bounce log to Mailtrain listener
 # If enabled, tail mail.log to Mailtrain with the following command:

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -17,7 +17,16 @@ try {
     LdapStrategy = require('passport-ldapjs').Strategy; // eslint-disable-line global-require
 } catch (E) {
     if (config.ldap.enabled) {
-        log.info('LDAP', 'Module "passport-ldapjs" not installed. LDAP auth will fail.');
+        log.info('LDAP', 'Module "passport-ldapjs" not installed. It will not be used for LDAP auth.');
+    }
+}
+
+let LdapAuthStrategy;
+try {
+    LdapAuthStrategy = require('passport-ldapauth').Strategy; // eslint-disable-line global-require
+} catch (E) {
+    if (config.ldapauth.enabled) {
+        log.info('LDAP', 'Module "passport-ldapauth" not installed. It will not be used for LDAP auth.');
     }
 }
 
@@ -44,7 +53,8 @@ module.exports.logout = (req, res) => {
 };
 
 module.exports.login = (req, res, next) => {
-    passport.authenticate(config.ldap.enabled ? 'ldap' : 'local', (err, user, info) => {
+    let authMode = config.ldapauth.enabled ? 'ldapauth' : config.ldap.enabled ? 'ldap' : 'local';
+    passport.authenticate(authMode, (err, user, info) => {
         if (err) {
             req.flash('danger', err.message);
             return next(err);
@@ -73,7 +83,7 @@ module.exports.login = (req, res, next) => {
 };
 
 if (config.ldap.enabled && LdapStrategy) {
-    log.info('Using LDAP auth');
+    log.info('Using LDAP auth (passport-ldapjs)');
 
     let opts = {
         server: {
@@ -106,6 +116,45 @@ if (config.ldap.enabled && LdapStrategy) {
                     return done(null, {
                         id,
                         username: profile[config.ldap.uidTag]
+                    });
+                });
+            } else {
+                return done(null, {
+                    id: user.id,
+                    username: user.username
+                });
+            }
+        });
+    }));
+} else if (config.ldapauth.enabled && LdapAuthStrategy) {
+    log.info("Using LDAP auth (passport-ldapauth)");
+    let opts = {
+        server: {
+            url: 'ldap://' + config.ldap.host + ':' + config.ldap.port,
+	    searchBase: config.ldapauth.baseDN,
+	    searchFilter: config.ldapauth.filter,
+            searchAttributes: [config.ldapauth.uidTag, 'mail'],
+            bindDN: config.ldapauth.bindUser,
+            bindCredentials: config.ldapauth.bindPassword
+        },
+    };
+
+    passport.use(new LdapAuthStrategy(opts, (profile, done) => {
+        users.findByUsername(profile[config.ldapauth.uidTag], (err, user) => {
+            if (err) {
+                return done(err);
+            }
+
+            if (!user) {
+                // password is empty for ldap
+                users.add(profile[config.ldapauth.uidTag], '', profile.mail, (err, id) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    return done(null, {
+                        id,
+                        username: profile[config.ldapauth.uidTag]
                     });
                 });
             } else {


### PR DESCRIPTION
passport-ldapjs wasn't working for me, as the DN it generates for the initial bind somehow doesn't work at all with our SAMBA AD. To fix this I added support for the (much more popular) passport-ldapauth library. That one works like a charm.

I'm not sure Mailtrain should support multiple ldap libraries, so I would propose removing passport-ldapjs support. Then we probably also should modify the configuration variables to be as close as possible to the passport-ldapauth ones.