### PR TITLE
Allow CORS headers to set in `api/*`

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -14,7 +14,6 @@ let _ = require('./translate')._;
 let util = require('util');
 let createDOMPurify = require('dompurify');
 let htmlToText = require('html-to-text');
-let config = require('config');
 
 let blockedUsers = ['abuse', 'admin', 'billing', 'compliance', 'devnull', 'dns', 'ftp', 'hostmaster', 'inoc', 'ispfeedback', 'ispsupport', 'listrequest', 'list', 'maildaemon', 'noc', 'noreply', 'noreply', 'null', 'phish', 'phishing', 'postmaster', 'privacy', 'registrar', 'root', 'security', 'spam', 'support', 'sysadmin', 'tech', 'undisclosedrecipients', 'unsubscribe', 'usenet', 'uucp', 'webmaster', 'www'];
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -14,6 +14,7 @@ let _ = require('./translate')._;
 let util = require('util');
 let createDOMPurify = require('dompurify');
 let htmlToText = require('html-to-text');
+let config = require('config');
 
 let blockedUsers = ['abuse', 'admin', 'billing', 'compliance', 'devnull', 'dns', 'ftp', 'hostmaster', 'inoc', 'ispfeedback', 'ispsupport', 'listrequest', 'list', 'maildaemon', 'noc', 'noreply', 'noreply', 'null', 'phish', 'phishing', 'postmaster', 'privacy', 'registrar', 'root', 'security', 'spam', 'support', 'sysadmin', 'tech', 'undisclosedrecipients', 'unsubscribe', 'usenet', 'uucp', 'webmaster', 'www'];
 
@@ -30,6 +31,7 @@ module.exports = {
     prepareHtml,
     purifyHTML,
     mergeTemplateIntoLayout,
+    getCorsOptions,
     workers: new Set()
 };
 
@@ -318,3 +320,24 @@ function mergeTemplateIntoLayout(template, layout, callback) {
         return done(template, layout);
     }
 }
+
+    function getCorsOptions() {
+        let originWhitelist = config.cors && config.cors.origins || [];
+
+        let corsOptions = {
+            allowedHeaders: ['Content-Type', 'Origin', 'Accept', 'X-Requested-With'],
+            methods: ['GET', 'POST'],
+            optionsSuccessStatus: 200, // IE11 chokes on 204
+            origin: (origin, callback) => {
+                if (originWhitelist.includes(origin)) {
+                    callback(null, true);
+                } else {
+                    let err = new Error(_('Not allowed by CORS'));
+                    err.status = 403;
+                    callback(err);
+                }
+            }
+        };
+
+        return corsOptions;
+    }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -329,11 +329,11 @@ function getCorsOptions() {
         optionsSuccessStatus: 200, // IE11 chokes on 204
         origin: (origin, callback) => {
             if (originWhitelist.includes(origin)) {
-                callback(null, true);
+                return callback(null, true);
             } else {
                 let err = new Error(_('Not allowed by CORS'));
                 err.status = 403;
-                callback(err);
+                return callback(err);
             }
         }
     };

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -320,23 +320,23 @@ function mergeTemplateIntoLayout(template, layout, callback) {
     }
 }
 
-    function getCorsOptions() {
-        let originWhitelist = config.cors && config.cors.origins || [];
+function getCorsOptions() {
+    let originWhitelist = config.cors && config.cors.origins || [];
 
-        let corsOptions = {
-            allowedHeaders: ['Content-Type', 'Origin', 'Accept', 'X-Requested-With'],
-            methods: ['GET', 'POST'],
-            optionsSuccessStatus: 200, // IE11 chokes on 204
-            origin: (origin, callback) => {
-                if (originWhitelist.includes(origin)) {
-                    callback(null, true);
-                } else {
-                    let err = new Error(_('Not allowed by CORS'));
-                    err.status = 403;
-                    callback(err);
-                }
+    let corsOptions = {
+        allowedHeaders: ['Content-Type', 'Origin', 'Accept', 'X-Requested-With'],
+        methods: ['GET', 'POST'],
+        optionsSuccessStatus: 200, // IE11 chokes on 204
+        origin: (origin, callback) => {
+            if (originWhitelist.includes(origin)) {
+                callback(null, true);
+            } else {
+                let err = new Error(_('Not allowed by CORS'));
+                err.status = 403;
+                callback(err);
             }
-        };
+        }
+    };
 
-        return corsOptions;
-    }
+    return corsOptions;
+}

--- a/routes/api.js
+++ b/routes/api.js
@@ -9,8 +9,11 @@ let confirmations = require('../lib/models/confirmations');
 let tools = require('../lib/tools');
 let express = require('express');
 let log = require('npmlog');
+let cors = require('cors');
 let router = new express.Router();
 let mailHelpers = require('../lib/subscription-mail-helpers');
+
+router.use(cors(tools.getCorsOptions));
 
 router.all('/*', (req, res, next) => {
     if (!req.query.access_token) {

--- a/routes/api.js
+++ b/routes/api.js
@@ -13,9 +13,7 @@ let cors = require('cors');
 let router = new express.Router();
 let mailHelpers = require('../lib/subscription-mail-helpers');
 
-router.use(cors(tools.getCorsOptions));
-
-router.all('/*', (req, res, next) => {
+router.all('/*', cors(tools.getCorsOptions()), (req, res, next) => {
     if (!req.query.access_token) {
         res.status(403);
         return res.json({

--- a/routes/subscription.js
+++ b/routes/subscription.js
@@ -19,7 +19,7 @@ let cache = require('memory-cache');
 let geoip = require('geoip-ultralight');
 let confirmations = require('../lib/models/confirmations');
 let mailHelpers = require('../lib/subscription-mail-helpers');
-let corsOptions = tools.corsOptions;
+let corsOptions = tools.getCorsOptions();
 
 let corsOrCsrfProtection = (req, res, next) => {
     if (req.get('X-Requested-With') === 'XMLHttpRequest') {

--- a/routes/subscription.js
+++ b/routes/subscription.js
@@ -20,26 +20,9 @@ let geoip = require('geoip-ultralight');
 let confirmations = require('../lib/models/confirmations');
 let mailHelpers = require('../lib/subscription-mail-helpers');
 
-let originWhitelist = config.cors && config.cors.origins || [];
-
-let corsOptions = {
-    allowedHeaders: ['Content-Type', 'Origin', 'Accept', 'X-Requested-With'],
-    methods: ['GET', 'POST'],
-    optionsSuccessStatus: 200, // IE11 chokes on 204
-    origin: (origin, callback) => {
-        if (originWhitelist.includes(origin)) {
-            callback(null, true);
-        } else {
-            let err = new Error(_('Not allowed by CORS'));
-            err.status = 403;
-            callback(err);
-        }
-    }
-};
-
 let corsOrCsrfProtection = (req, res, next) => {
     if (req.get('X-Requested-With') === 'XMLHttpRequest') {
-        cors(corsOptions)(req, res, next);
+        cors(tools.getCorsOptions)(req, res, next);
     } else {
         passport.csrfProtection(req, res, next);
     }

--- a/routes/subscription.js
+++ b/routes/subscription.js
@@ -19,10 +19,11 @@ let cache = require('memory-cache');
 let geoip = require('geoip-ultralight');
 let confirmations = require('../lib/models/confirmations');
 let mailHelpers = require('../lib/subscription-mail-helpers');
+let corsOptions = tools.corsOptions;
 
 let corsOrCsrfProtection = (req, res, next) => {
     if (req.get('X-Requested-With') === 'XMLHttpRequest') {
-        cors(tools.getCorsOptions)(req, res, next);
+        cors(corsOptions)(req, res, next);
     } else {
         passport.csrfProtection(req, res, next);
     }


### PR DESCRIPTION
Currently, CORS headers are only set in `routes/subscription.js`, so when a call is made to `/api/subscribe/:list_id`, there will be a "No 'Access-Control-Allow-Origin' header" error.

This PR moves the logic of the CORS Options into `lib/tools.js` so that it can be used in both `routes/api.js` and `routes/subscriptions.js`.

Do let me know if `lib/tools.js` is a suitable place for this function, and thanks @brentdur for the help!