### PR TITLE
Fix spelling in email field help block.

### DIFF
--- a/languages/de_DE.po
+++ b/languages/de_DE.po
@@ -2900,7 +2900,7 @@ msgstr "Ihre E-Mail-Adresse"
 
 #: views/users/account.hbs:9
 msgid ""
-"This address is used for account recovery in case you loose your password"
+"This address is used for account recovery in case you lose your password"
 msgstr ""
 "Diese Adresse wird für die Wiederherstellung des Kontos verwendet, falls Sie "
 "Ihr Passwort vergessen haben"

--- a/languages/es_ES.po
+++ b/languages/es_ES.po
@@ -3027,7 +3027,7 @@ msgstr "Tu dirección email"
 
 #: views/users/account.hbs:9
 msgid ""
-"This address is used for account recovery in case you loose your password"
+"This address is used for account recovery in case you lose your password"
 msgstr ""
 "Este email es usado para recuperar una cuenta en caso de que no recuerdes la "
 "contraseña"

--- a/languages/et.po
+++ b/languages/et.po
@@ -2300,7 +2300,7 @@ msgstr ""
 
 #: views/users/account.hbs:9
 msgid ""
-"This address is used for account recovery in case you loose your password"
+"This address is used for account recovery in case you lose your password"
 msgstr ""
 
 #: views/users/account.hbs:10

--- a/languages/it_IT.po
+++ b/languages/it_IT.po
@@ -2944,7 +2944,7 @@ msgstr "Il tuo indirizzo email"
 
 #: views/users/account.hbs:9
 msgid ""
-"This address is used for account recovery in case you loose your password"
+"This address is used for account recovery in case you lose your password"
 msgstr "Questo indirizzo è utilizzato per il recupero della password"
 
 #: views/users/account.hbs:10

--- a/views/users/account.hbs
+++ b/views/users/account.hbs
@@ -27,7 +27,7 @@
                 <label for="email" class="col-sm-2 control-label">{{#translate}}Email Address{{/translate}}</label>
                 <div class="col-sm-10">
                     <input type="email" class="form-control" name="email" id="email" value="{{email}}" placeholder="{{#translate}}Your e-mail address{{/translate}}" required>
-                    <span class="help-block">{{#translate}}This address is used for account recovery in case you loose your password{{/translate}}</span>
+                    <span class="help-block">{{#translate}}This address is used for account recovery in case you lose your password{{/translate}}</span>
                 </div>
             </div>
 


### PR DESCRIPTION
Changed

> This address is used for account recovery in case you loose your password

to

> This address is used for account recovery in case you lose your password