### PR TITLE
API functionality: get all lists, get list by id

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -348,6 +348,22 @@ router.get('/subscriptions/:listId', (req, res) => {
     });
 });
 
+router.get('/lists', (req, res) => {
+    lists.quicklist((err, lists) => {
+        if (err) {
+            res.status(500);
+            return res.json({
+                error: err.message || err,
+                data: []
+            });
+        }
+        res.status(200);
+        res.json({
+            data: lists
+        });
+    });
+});
+
 router.get('/lists/:email', (req, res) => {
     lists.getListsWithEmail(req.params.email, (err, lists) => {
         if (err) {

--- a/routes/api.js
+++ b/routes/api.js
@@ -364,6 +364,21 @@ router.get('/lists', (req, res) => {
     });
 });
 
+router.get('/list/:id', (req, res) => {
+    lists.get(req.params.id, (err, list) => {
+        if (err) {
+            res.status(500);
+            return res.json({
+                error: err.message || err,
+            });
+        }
+        res.status(200);
+        res.json({
+            data: list
+        });
+    });
+});
+
 router.get('/lists/:email', (req, res) => {
     lists.getListsWithEmail(req.params.email, (err, lists) => {
         if (err) {

--- a/views/users/api.hbs
+++ b/views/users/api.hbs
@@ -315,3 +315,22 @@
 </p>
 
 <pre>curl -XGET '{{serviceUrl}}api/lists?access_token={{accessToken}}'</pre>
+
+<h3>GET /api/list/:id – {{#translate}}Get list by id{{/translate}}</h3>
+
+<p>
+  {{#translate}}Retrieve the list with :id {{/translate}}
+</p>
+
+<p>
+  <strong>GET</strong> {{#translate}}arguments{{/translate}}
+</p>
+<ul>
+  <li><strong>access_token</strong> – {{#translate}}your personal access token{{/translate}}
+</ul>
+
+<p>
+  <strong>{{#translate}}Example{{/translate}}</strong>
+</p>
+
+<pre>curl -XGET '{{serviceUrl}}api/list/1?access_token={{accessToken}}'</pre>

--- a/views/users/api.hbs
+++ b/views/users/api.hbs
@@ -296,3 +296,22 @@
 </p>
 
 <pre>curl -XGET '{{serviceUrl}}api/lists/test@example.com?access_token={{accessToken}} </pre>
+
+<h3>GET /api/lists – {{#translate}}Get all lists{{/translate}}</h3>
+
+<p>
+  {{#translate}}Retrieve every list. {{/translate}}
+</p>
+
+<p>
+  <strong>GET</strong> {{#translate}}arguments{{/translate}}
+</p>
+<ul>
+  <li><strong>access_token</strong> – {{#translate}}your personal access token{{/translate}}
+</ul>
+
+<p>
+  <strong>{{#translate}}Example{{/translate}}</strong>
+</p>
+
+<pre>curl -XGET '{{serviceUrl}}api/lists?access_token={{accessToken}}'</pre>


### PR DESCRIPTION
Hello! 
I extended the api with a 'get all lists' endpoint (/api/lists) and a 'get list by id' (/api/list:id) endpoint. I also documented these endpoints on the api admin page. Let me know if this needs any changes. (I could also split them in seperate PRs if needed)

On behalf of GUNet, 
gsiou