### PR TITLE
Fix newsletter signup link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 * Email templates
 * Large CSV list import files
 
-Subscribe to Mailtrain Newsletter [here](http://mailtrain.org/subscription/EysIv8sAx) (uses Mailtrain obviously)
+Subscribe to Mailtrain Newsletter [here](https://mailtrain.org/subscription/S18sew2wM) (uses Mailtrain obviously)
 
 ## Hardware Requirements
 * 1 vCPU


### PR DESCRIPTION
I replaced the link with the one from the mailtrain.org homepage:

![image](https://user-images.githubusercontent.com/7661/40438211-16793584-5e7d-11e8-9b6d-986ebde1cb8a.png)
