### PR TITLE
Add option on list to disable "List-Unsubscribe" header

### DIFF
--- a/lib/models/lists.js
+++ b/lib/models/lists.js
@@ -19,7 +19,7 @@ const UnsubscriptionMode = {
 
 module.exports.UnsubscriptionMode = UnsubscriptionMode;
 
-let allowedKeys = ['description', 'default_form', 'public_subscribe', 'unsubscription_mode'];
+let allowedKeys = ['description', 'default_form', 'public_subscribe', 'unsubscription_mode', 'listunsubscribe_disabled'];
 
 module.exports.list = (start, limit, callback) => {
     tableHelpers.list('lists', ['*'], 'name', null, start, limit, callback);
@@ -158,6 +158,7 @@ module.exports.update = (id, updates, callback) => {
     // The update can be only partial when executed from forms/:list
     if (!data.customFormChangeOnly) {
         data.publicSubscribe = data.publicSubscribe ? 1 : 0;
+        data.listunsubscribeDisabled = data.listunsubscribeDisabled ? 1 : 0;
         data.unsubscriptionMode = Number(data.unsubscriptionMode);
 
         let name = (data.name || '').toString().trim();

--- a/meta.json
+++ b/meta.json
@@ -1,3 +1,3 @@
 {
-    "schemaVersion": 29
+    "schemaVersion": 30
 }

--- a/services/sender.js
+++ b/services/sender.js
@@ -379,6 +379,11 @@ function formatMessage(message, callback) {
                                     wordwrap: 130
                                 });
 
+                                let listUnsubscribe = null;
+                                if (!list.listunsubscribeDisabled) {
+                                    listUnsubscribe = url.resolve(configItems.serviceUrl, '/subscription/' + list.cid + '/unsubscribe/' + message.subscription.cid);
+                                }
+
                                 return callback(null, {
                                     from: {
                                         name: campaign.from,
@@ -419,7 +424,7 @@ function formatMessage(message, callback) {
                                         }
                                     },
                                     list: {
-                                        unsubscribe: url.resolve(configItems.serviceUrl, '/subscription/' + list.cid + '/unsubscribe/' + message.subscription.cid)
+                                        unsubscribe: listUnsubscribe
                                     },
                                     subject: tools.formatMessage(configItems.serviceUrl, campaign, list, message.subscription, campaign.subject),
                                     html: renderedHtml,

--- a/setup/sql/upgrade-00030.sql
+++ b/setup/sql/upgrade-00030.sql
@@ -1,0 +1,17 @@
+# Header section
+# Define incrementing schema version number
+SET @schema_version = '30';
+
+# Upgrade script section
+#### INSERT YOUR UPGRADE SCRIPT BELOW THIS LINE ######
+
+ALTER TABLE `lists` ADD COLUMN `listunsubscribe_disabled` tinyint(4) unsigned DEFAULT 0 NOT NULL;
+
+#### INSERT YOUR UPGRADE SCRIPT ABOVE THIS LINE ######
+
+# Footer section. Updates schema version in settings
+LOCK TABLES `settings` WRITE;
+/*!40000 ALTER TABLE `settings` DISABLE KEYS */;
+INSERT INTO `settings` (`key`, `value`) VALUES('db_schema_version', @schema_version) ON DUPLICATE KEY UPDATE `value`=@schema_version;
+/*!40000 ALTER TABLE `settings` ENABLE KEYS */;
+UNLOCK TABLES;

--- a/views/lists/edit.hbs
+++ b/views/lists/edit.hbs
@@ -80,6 +80,17 @@
         </div>
     </div>
 
+    <div class="form-group">
+        <label for="default_form" class="col-sm-2 control-label">{{#translate}}Unsubscribe Header{{/translate}}</label>
+        <div class="col-sm-10">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="listunsubscribe_disabled" value="1" {{#if listunsubscribeDisabled}} checked {{/if}}> {{#translate}}Do not send List-Unsubscribe headers{{/translate}}
+                </label>
+            </div>
+        </div>
+    </div>
+
     <hr />
 
     <div class="form-group">


### PR DESCRIPTION
Addressing #422

I've added a mysql column `lists.listunsubscribe_disabled`, defaulting to "0" and a corresponding field in the model. I've done some acceptance testing and have confirmed that it behaves as expected.

I'm not sure about the description and placement of the option. For now it's only visible on the *edit* page but not on the *create* page of a list (with the reasoning that this is a rather edge case configuration). Please let me know if there's a better way to do it.

@bures wdyt?