### PR TITLE
LDAP SSL Support

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -114,8 +114,7 @@ host="0.0.0.0"
 [ldap]
 # enable to use ldap user backend
 enabled=false
-host="localhost"
-port=3002
+url="ldap://localhost:3002"
 baseDN="ou=users,dc=company"
 filter="(|(username={{username}})(mail={{username}}))"
 #Username field in LDAP (uid/cn/username)
@@ -128,8 +127,7 @@ bindPassword=""
 [ldapauth]
 # Alternative LDAP implementation using the more popular passport-ldapauth library.
 enabled=false
-host="localhost"
-port=389
+url="ldap://localhost:389"
 # Subtree in which the searchrequest for the user is done
 baseDN="ou=users,dc=company"
 # What whe are searching for. This should return a single user.

--- a/config/default.toml
+++ b/config/default.toml
@@ -123,6 +123,7 @@ passwordresetlink=""
 # Use a different user to bind LDAP (final bind DN will be: {{uidTag}}={{bindUser}},{{baseDN}})
 bindUser=""
 bindPassword=""
+#ca="self-signed-ca.pem"
 
 [ldapauth]
 # Alternative LDAP implementation using the more popular passport-ldapauth library.
@@ -138,6 +139,7 @@ passwordresetlink=""
 # Credentials for the initial search operation (final bind DN will be exactly as specified)
 bindUser="name@company.net"
 bindPassword="mySecretPassword"
+#ca="self-signed-ca.pem"
 
 [postfixbounce]
 # Enable to allow writing Postfix bounce log to Mailtrain listener

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -6,6 +6,7 @@ let _ = require('./translate')._;
 let util = require('util');
 
 let passport = require('passport');
+let fs = require('fs');
 let LocalStrategy = require('passport-local').Strategy;
 
 let csrf = require('csurf');
@@ -87,7 +88,12 @@ if (config.ldap.enabled && LdapStrategy) {
 
     let opts = {
         server: {
-            url: config.ldap.url
+            url: config.ldap.url,
+            tlsOptions: {
+                ca: config.ldap.ca ? [
+                    fs.readFileSync(config.ldap.ca)
+                ] : undefined
+            }
         },
         base: config.ldap.baseDN,
         search: {
@@ -135,7 +141,12 @@ if (config.ldap.enabled && LdapStrategy) {
             searchFilter: config.ldapauth.filter,
             searchAttributes: [config.ldapauth.uidTag, 'mail'],
             bindDN: config.ldapauth.bindUser,
-            bindCredentials: config.ldapauth.bindPassword
+            bindCredentials: config.ldapauth.bindPassword,
+            tlsOptions: {
+                ca: config.ldapauth.ca ? [
+                    fs.readFileSync(config.ldapauth.ca)
+                ] : undefined
+            }
         }
     };
 

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -87,7 +87,7 @@ if (config.ldap.enabled && LdapStrategy) {
 
     let opts = {
         server: {
-            url: 'ldap://' + config.ldap.host + ':' + config.ldap.port
+            url: config.ldap.url
         },
         base: config.ldap.baseDN,
         search: {
@@ -130,7 +130,7 @@ if (config.ldap.enabled && LdapStrategy) {
     log.info('Using LDAP auth (passport-ldapauth)');
     let opts = {
         server: {
-            url: 'ldap://' + config.ldap.host + ':' + config.ldap.port,
+            url: config.ldapauth.url,
             searchBase: config.ldapauth.baseDN,
             searchFilter: config.ldapauth.filter,
             searchAttributes: [config.ldapauth.uidTag, 'mail'],


### PR DESCRIPTION
Please find submitted a suggestion to enable LDAPS without destroying LDAP compatibility.
For enabling this, the configuration file was changed from host and port to url so that the previously hardcoded 'ldap://' is now in the scope of the user.
One difficulty of ldaps:// connectivity is that nodejs does not use the system-wide installed CAs but (like Firefox does) only supports Mozilla provided certificates (see [tls_tls_createsecurecontext_options](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options)). This is why an optional ca config item was added for providing a self-signed certificate or ca (not needed with ldap://).
What is currently still unsupported is StartTLS as this requires a different stream processing of the connection. [ldap-js supports this](http://ldapjs.org/client.html#starttls), but this is more complicated and LDAP servers that support (or require) StartTLS are easily configured to support standalone SSL, as well, so not supporting StartTLS is no real blocker.

I hope you acknowledge these changes! I tested for myself and was able to successfully login via SSL.