### PR TITLE
Enabling HTTPS server side support

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -61,6 +61,16 @@ level="verbose"
 port=3000
 # HTTP interface to listen on
 host="0.0.0.0"
+# Enable HTTPS
+https=false
+# HTTPS certificate file name
+cert="cert.pem"
+# HTTPS certificate private key file name
+key="key.pem"
+# HTTPS ca certificate file name
+#ca="ca-certificate.pem"
+# HTTPS Diffie Hellman parameters (generate with openssl dhparam)
+#dhparams="dhparams.pem"
 # Secret for signing the session ID cookie
 secret="a cat"
 # Session length in seconds when "remember me" is checked

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ const config = require('config');
 const log = require('npmlog');
 const app = require('./app');
 const http = require('http');
+const https = require('https');
+const fs = require('fs');
 const fork = require('child_process').fork;
 const triggers = require('./services/triggers');
 const importer = require('./services/importer');
@@ -33,10 +35,15 @@ log.level = config.log.level;
 app.set('port', port);
 
 /**
- * Create HTTP server.
+ * Create HTTP/HTTPS server.
  */
 
-let server = http.createServer(app);
+let server = (!config.www.https) ? http.createServer(app) : https.createServer({
+    cert: fs.readFileSync(config.www.cert),
+    key: fs.readFileSync(config.www.key),
+    ca: fs.readFileSync(config.www.ca),
+    dhparams: fs.readFileSync(config.www.dhparams)
+}, app);
 
 // Check if database needs upgrading before starting the server
 dbcheck(err => {

--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ app.set('port', port);
 let server = (!config.www.https) ? http.createServer(app) : https.createServer({
     cert: fs.readFileSync(config.www.cert),
     key: fs.readFileSync(config.www.key),
-    ca: fs.readFileSync(config.www.ca),
-    dhparams: fs.readFileSync(config.www.dhparams)
+    ca: config.www.ca ? fs.readFileSync(config.www.ca) : undefined,
+    dhparams: config.www.dhparams ? fs.readFileSync(config.www.dhparams) : undefined
 }, app);
 
 // Check if database needs upgrading before starting the server


### PR DESCRIPTION
this permits [https](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) as asked in #262 
it can be enabled or disabled by the new config options.
it is possible to serve certificate, keyfile, ca-certificate if needed and dhparams if needed.
I tested with and without dhparams and with and without https enabled, it worked as assumed.