### PR TITLE
Warn on failed login

### DIFF
--- a/lib/passport.js
+++ b/lib/passport.js
@@ -60,6 +60,7 @@ module.exports.login = (req, res, next) => {
             return next(err);
         }
         if (!user) {
+            log.warn('auth', `[client ${req.ip}] authentication failure`);
             req.flash('danger', info && info.message || _('Failed to authenticate user'));
             return res.redirect('/users/login' + (req.body.next ? '?next=' + encodeURIComponent(req.body.next) : ''));
         }


### PR DESCRIPTION
This makes it possible to use fail2ban to block suspicious login attempts.