### PR TITLE
add passport-ldapauth to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "openpgp": "^2.5.11",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
+    "passport-ldapauth": "^2.0.0",
     "premailer-api": "^1.0.4",
     "redfour": "^1.0.2",
     "redis": "^2.8.0",


### PR DESCRIPTION
when "npm install --production" is called, every time, passport-ldapauth is removed from local repository, with adding the dependency to package.json, the behavior is as expected (see production.yml config for ldap config)