### PR TITLE
Ignore more config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,9 @@ node_modules
 npm-debug.log
 package-lock.json
 .DS_Store
-config/development.*
-config/production.*
-config/test.*
+config/development*
+config/production*
+config/test*
 workers/reports/config/development.*
 workers/reports/config/production.*
 workers/reports/config/test.*


### PR DESCRIPTION
To run multiple instances, you need to create files like `production-1.toml`, `production-1.toml`, etc. as described in #103 

These config files should be ignored too.