### PR TITLE
API: Add the possibility to change the email address of an existing list subscriber

### DIFF
--- a/lib/models/segments.js
+++ b/lib/models/segments.js
@@ -574,11 +574,12 @@ module.exports.getQuery = (id, prefix, callback) => {
 
         segment.rules.forEach(rule => {
             switch (rule.columnType.type) {
-                case 'string':
+                case 'string': {
                     let condition = rule.value.negate ? 'NOT LIKE' : 'LIKE';
                     query.push(prefix + '`' + rule.columnType.column + '` ' + condition + ' ?');
                     values.push(rule.value.value);
                     break;
+                }
                 case 'boolean':
                     query.push(prefix + '`' + rule.columnType.column + '` = ?');
                     values.push(rule.value.value);

--- a/routes/api.js
+++ b/routes/api.js
@@ -524,4 +524,111 @@ router.get('/blacklist/get', (req, res) => {
     });
 });
 
+router.post('/changeemail/:listId', (req, res) => {
+    let input = {};
+    Object.keys(req.body).forEach(key => {
+        input[(key || '').toString().trim().toUpperCase()] = (req.body[key] || '').toString().trim();
+    });
+    if (!(input.EMAILOLD) || (input.EMAILOLD === ''))  {
+      res.status(500);
+      return res.json({
+          error: 'EMAILOLD argument is required',
+          data: []
+      });
+    }
+    if (!(input.EMAILNEW) || (input.EMAILNEW === ''))  {
+      res.status(500);
+      return res.json({
+          error: 'EMAILNEW argument is required',
+          data: []
+      });
+    }
+    lists.getByCid(req.params.listId, (err, list) => {
+        if (err) {
+            log.error('API', err);
+            res.status(500);
+            return res.json({
+                error: err.message || err,
+                data: []
+            });
+        }
+        if (!list) {
+            res.status(404);
+            return res.json({
+                error: 'Selected listId not found',
+                data: []
+            });
+        }
+        blacklist.isblacklisted(input.EMAILNEW, (err, blacklisted) =>{
+          if (err) {
+              res.status(500);
+              return res.json({
+                  error: err.message || err,
+                  data: []
+              });
+          }
+          if (blacklisted) {
+            res.status(500);
+            return res.json({
+                error: 'New email is blacklisted',
+                data: []
+            });
+          }
+
+          subscriptions.getByEmail(list.id, input.EMAILOLD, (err, subscription) => {
+              if (err) {
+                  res.status(500);
+                  return res.json({
+                      error: err.message || err,
+                      data: []
+                  });
+              }
+
+              if (!subscription) {
+                  res.status(404);
+                  return res.json({
+                      error: 'Subscription with given old email not found',
+                      data: []
+                  });
+              }
+
+              subscriptions.updateAddressCheck(list, subscription.cid, input.EMAILNEW, null, (err, old, valid) => {
+                  if (err) {
+                      res.status(500);
+                      return res.json({
+                          error: err.message || err,
+                          data: []
+                      });
+                  }
+
+                  if (!valid) {
+                      res.status(500);
+                      return res.json({
+                          error: 'New email not valid',
+                          data: []
+                      });
+                  }
+
+                  subscriptions.updateAddress(list.id, subscription.id, input.EMAILNEW, (err) => {
+                      if (err) {
+                          res.status(500);
+                          return res.json({
+                              error: err.message || err,
+                              data: []
+                          });
+                      }
+                      res.status(200);
+                      res.json({
+                          data: {
+                              id: subscription.id,
+                              changedemail: true
+                          }
+                      });
+                  });
+              });
+          });
+        });
+    });
+});
+
 module.exports = router;

--- a/views/users/api.hbs
+++ b/views/users/api.hbs
@@ -334,3 +334,31 @@
 </p>
 
 <pre>curl -XGET '{{serviceUrl}}api/list/1?access_token={{accessToken}}'</pre>
+
+<h3>POST /api/changeemail/:listId – {{#translate}}Change email of existing list subscriber{{/translate}}</h3>
+
+<p>
+    {{#translate}}This API call changes the email address of an existing list subscriber.{{/translate}}
+</p>
+
+<p>
+    <strong>GET</strong> {{#translate}}arguments{{/translate}}
+</p>
+<ul>
+    <li><strong>access_token</strong> – {{#translate}}your personal access token{{/translate}}
+</ul>
+
+<p>
+    <strong>POST</strong> {{#translate}}arguments{{/translate}}
+</p>
+<ul>
+    <li><strong>EMAILOLD</strong> – {{#translate}}subscriber's old email address{{/translate}} (<em>{{#translate}}required{{/translate}}</em>)
+    <li><strong>EMAILNEW</strong> – {{#translate}}subscriber's new email address{{/translate}} (<em>{{#translate}}required{{/translate}}</em>)
+</ul>
+
+<p>
+    <strong>{{#translate}}Example{{/translate}}</strong>
+</p>
+
+<pre>curl -XPOST {{serviceUrl}}api/changeemail/B16uVTdW?access_token={{accessToken}} \
+--data 'EMAILOLD=test@example.com&EMAILNEW=foo@bar.com'</pre>


### PR DESCRIPTION
This commit adds a `/changeemail/:listId` route that can be used to change the email address of an existing list subscriber. It is checked that the new email address is valid and not on the blacklist.