### PR TITLE
Adds 'type' property to migration of text-based segment rules

### DIFF
--- a/server/setup/knex/migrations/20170506102634_v1_to_v2.js
+++ b/server/setup/knex/migrations/20170506102634_v1_to_v2.js
@@ -528,7 +528,7 @@ async function migrateSegments(knex) {
                 case 'text':
                 case 'string':
                 case 'website':
-                    rules.push({ column: oldRule.column, value: oldSettings.value });
+                    rules.push({ type: 'like', column: oldRule.column, value: oldSettings.value });
                     break;
                 case 'number':
                     if (oldSettings.range) {


### PR DESCRIPTION
In v2, text-based segment rules need a `type` property. As in v1 the value could contain `%` wildcards, the default type for migrated rules should be `like` to support them.