### PR TITLE
Dockerfile update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM node:10.14-jessie
+FROM node:10.14-alpine
 
-RUN apt-get update && apt-get install -y pwgen netcat
+RUN apk add --update pwgen netcat-openbsd python make gcc git g++ bash
 
 # First install dependencies
 COPY server/package.json /app/server/package.json
+COPY server/package-lock.json /app/server/package-lock.json
 COPY client/package.json /app/client/package.json
+COPY client/package-lock.json /app/client/package-lock.json
 COPY shared/package.json /app/shared/package.json
+COPY shared/package-lock.json /app/shared/package-lock.json
 COPY zone-mta/package.json /app/zone-mta/package.json
+COPY zone-mta/package-lock.json /app/zone-mta/package-lock.json
 
 WORKDIR /app/
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,9 @@ Optional parameters:
   --sandboxUrlBase XXX  - sets the sandbox url of the instance (default: http://localhost:3003)
   --publicUrlBase XXX   - sets the public url of the instance (default: http://localhost:3004)
   --withProxy           - use if Mailtrain is behind an http reverse proxy
+  --mongoHost XXX       - sets mongo host (default: mongo)
+  --redisHost XXX       - sets redis host (default: redis)
+  --mySqlHost XXX       - sets mysql host (default: mysql)
 EOF
 
     exit 1
@@ -19,6 +22,9 @@ urlBaseTrusted=http://localhost:3000
 urlBaseSandbox=http://localhost:3003
 urlBasePublic=http://localhost:3004
 wwwProxy=false
+mongoHost=mongo
+redisHost=redis
+mySqlHost=mysql
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -41,6 +47,18 @@ while [ $# -gt 0 ]; do
             wwwProxy=true
             shift 1
             ;;
+        --mongoHost)
+            mongoHost="$2"
+            shift 2
+            ;;
+        --redisHost)
+            redisHost="$2"
+            shift 2
+            ;;
+        --mySqlHost)
+            mySqlHost="$2"
+            shift 2
+            ;;
         *)
             echo "Error: unrecognized option $1."
             printHelp
@@ -58,11 +76,11 @@ www:
   publicUrlBase: $urlBasePublic
 
 mysql:
-  host: mysql
+  host: $mySqlHost
 
 redis:
   enabled: true
-  host: redis
+  host: $redisHost
 
 log:
   level: info
@@ -70,8 +88,8 @@ log:
 builtinZoneMTA:
   log:
     level: warn
-  mongo: mongodb://mongo:27017/zone-mta
-  redis: redis://redis:6379/2
+  mongo: mongodb://${mongoHost}:27017/zone-mta
+  redis: redis://${redisHost}:6379/2
 
 queue:
   processes: 5
@@ -83,9 +101,9 @@ log:
 EOT
 
 # Wait for the other services to start
-while ! nc -z mysql 3306; do sleep 1; done
-while ! nc -z redis 6379; do sleep 1; done
-while ! nc -z mongo 27017; do sleep 1; done
+while ! nc -z $mySqlHost 3306; do sleep 1; done
+while ! nc -z $redisHost 6379; do sleep 1; done
+while ! nc -z $mongoHost 27017; do sleep 1; done
 
 cd server
 NODE_ENV=production node index.js


### PR DESCRIPTION
- `node:10-14-alpine `image is used (because `jessie` is oudated and can not install packages
- added package-lock.json to make sure the same dependencies' versions are used
- added an option to pass redisHost, mongoHost, mysqlHost to use in Kubernetes cluster