### PR TITLE
[DO NOT MERGE] Change REST API endpoints to also accept list name as a list identifier

### DIFF
--- a/lib/models/links.js
+++ b/lib/models/links.js
@@ -337,7 +337,7 @@ function getSubscriptionData(campaignCid, listCid, subscriptionCid, callback) {
             return callback(new Error(_('Campaign not found')));
         }
 
-        lists.getByCid(listCid, (err, list) => {
+        lists.getByCidOrName(listCid, (err, list) => {
             if (err) {
                 return callback(err);
             }

--- a/lib/models/lists.js
+++ b/lib/models/lists.js
@@ -96,8 +96,8 @@ module.exports.getListsWithEmail = (email, callback) => {
     });
 };
 
-module.exports.getByCid = (cid, callback) => {
-    resolveCid(cid, (err, id) => {
+module.exports.getByCidOrName = (list, callback) => {
+    resolveCidOrName(list, (err, id) => {
         if (err) {
             return callback(err);
         }
@@ -109,9 +109,9 @@ module.exports.getByCid = (cid, callback) => {
 };
 
 module.exports.get = (id, callback) => {
-    id = Number(id) || 0;
+    id = Number(id) || id;
 
-    if (id < 1) {
+    if (!id || Number(id) < 1) {
         return callback(new Error(_('Missing List ID')));
     }
 
@@ -120,7 +120,7 @@ module.exports.get = (id, callback) => {
             return callback(err);
         }
 
-        connection.query('SELECT * FROM lists WHERE id=?', [id], (err, rows) => {
+        connection.query('SELECT * FROM lists WHERE id=? OR name=?', [id, id], (err, rows) => {
             connection.release();
             if (err) {
                 return callback(err);
@@ -288,17 +288,17 @@ module.exports.delete = (id, callback) => {
     });
 };
 
-function resolveCid(cid, callback) {
-    cid = (cid || '').toString().trim();
-    if (!cid) {
-        return callback(new Error(_('Missing List CID')));
+function resolveCidOrName(list, callback) {
+    list = (list || '').toString().trim();
+    if (!list) {
+        return callback(new Error(_('Missing List Identifier (CID or name)')));
     }
 
     db.getConnection((err, connection) => {
         if (err) {
             return callback(err);
         }
-        connection.query('SELECT id FROM lists WHERE cid=?', [cid], (err, rows) => {
+        connection.query('SELECT id FROM lists WHERE cid=? OR name=?', [list, list], (err, rows) => {
             connection.release();
             if (err) {
                 return callback(err);

--- a/routes/api.js
+++ b/routes/api.js
@@ -41,12 +41,12 @@ router.all('/*', (req, res, next) => {
 
 });
 
-router.post('/subscribe/:listId', (req, res) => {
+router.post('/subscribe/:list', (req, res) => {
     let input = {};
     Object.keys(req.body).forEach(key => {
         input[(key || '').toString().trim().toUpperCase()] = (req.body[key] || '').toString().trim();
     });
-    lists.getByCid(req.params.listId, (err, list) => {
+    lists.getByCidOrName(req.params.list, (err, list) => {
         if (err) {
             log.error('API', err);
             res.status(500);
@@ -181,12 +181,12 @@ router.post('/subscribe/:listId', (req, res) => {
     });
 });
 
-router.post('/unsubscribe/:listId', (req, res) => {
+router.post('/unsubscribe/:list', (req, res) => {
     let input = {};
     Object.keys(req.body).forEach(key => {
         input[(key || '').toString().trim().toUpperCase()] = (req.body[key] || '').toString().trim();
     });
-    lists.getByCid(req.params.listId, (err, list) => {
+    lists.getByCidOrName(req.params.list, (err, list) => {
         if (err) {
             res.status(500);
             return res.json({
@@ -246,12 +246,12 @@ router.post('/unsubscribe/:listId', (req, res) => {
     });
 });
 
-router.post('/delete/:listId', (req, res) => {
+router.post('/delete/:list', (req, res) => {
     let input = {};
     Object.keys(req.body).forEach(key => {
         input[(key || '').toString().trim().toUpperCase()] = (req.body[key] || '').toString().trim();
     });
-    lists.getByCid(req.params.listId, (err, list) => {
+    lists.getByCidOrName(req.params.list, (err, list) => {
         if (err) {
             res.status(500);
             return res.json({
@@ -315,11 +315,11 @@ router.post('/delete/:listId', (req, res) => {
     });
 });
 
-router.get('/subscriptions/:listId', (req, res) => {
+router.get('/subscriptions/:list', (req, res) => {
     let start = parseInt(req.query.start || 0, 10);
     let limit = parseInt(req.query.limit || 10000, 10);
 
-    lists.getByCid(req.params.listId, (err, list) => {
+    lists.getByCidOrName(req.params.list, (err, list) => {
 	if (err) {
             res.status(500);
             return res.json({
@@ -395,12 +395,12 @@ router.get('/lists/:email', (req, res) => {
     });
 });
 
-router.post('/field/:listId', (req, res) => {
+router.post('/field/:list', (req, res) => {
     let input = {};
     Object.keys(req.body).forEach(key => {
         input[(key || '').toString().trim().toUpperCase()] = (req.body[key] || '').toString().trim();
     });
-    lists.getByCid(req.params.listId, (err, list) => {
+    lists.getByCidOrName(req.params.list, (err, list) => {
         if (err) {
             log.error('API', err);
             res.status(500);
@@ -525,7 +525,7 @@ router.get('/blacklist/get', (req, res) => {
     });
 });
 
-router.post('/changeemail/:listId', (req, res) => {
+router.post('/changeemail/:list', (req, res) => {
     let input = {};
     Object.keys(req.body).forEach(key => {
         input[(key || '').toString().trim().toUpperCase()] = (req.body[key] || '').toString().trim();
@@ -544,7 +544,7 @@ router.post('/changeemail/:listId', (req, res) => {
           data: []
       });
     }
-    lists.getByCid(req.params.listId, (err, list) => {
+    lists.getByCidOrName(req.params.list, (err, list) => {
         if (err) {
             log.error('API', err);
             res.status(500);

--- a/routes/archive.js
+++ b/routes/archive.js
@@ -33,7 +33,7 @@ router.get('/:campaign/:list/:subscription', passport.csrfProtection, (req, res,
                 return next(err);
             }
 
-            lists.getByCid(req.params.list, (err, list) => {
+            lists.getByCidOrName(req.params.list, (err, list) => {
                 if (err) {
                     req.flash('danger', err.message || err);
                     return res.redirect('/');

--- a/routes/links.js
+++ b/routes/links.js
@@ -67,7 +67,7 @@ router.get('/:campaign/:list/:subscription/:link', (req, res) => {
         }
 
         // url might include variables, need to rewrite those just as we do with message content
-        lists.getByCid(req.params.list, (err, list) => {
+        lists.getByCidOrName(req.params.list, (err, list) => {
             if (err) {
                 req.flash('danger', err.message || err);
                 return res.redirect('/');

--- a/routes/subscription.js
+++ b/routes/subscription.js
@@ -170,7 +170,7 @@ router.get('/confirm/unsubscribe/:cid', (req, res, next) => {
 });
 
 router.get('/:cid', passport.csrfProtection, (req, res, next) => {
-    lists.getByCid(req.params.cid, (err, list) => {
+    lists.getByCidOrName(req.params.cid, (err, list) => {
         if (!err) {
             if (!list) {
                 err = new Error(_('Selected list not found'));
@@ -281,7 +281,7 @@ router.get('/:cid/widget', cors(corsOptions), (req, res, next) => {
         });
     };
 
-    lists.getByCid(req.params.cid, (err, list) => {
+    lists.getByCidOrName(req.params.cid, (err, list) => {
         if (!err && !list) {
             err = new Error(_('Selected list not found'));
             err.status = 404;
@@ -376,7 +376,7 @@ router.post('/:cid/subscribe', passport.parseForm, corsOrCsrfProtection, (req, r
         let addressTest = !req.body.address;
         let testsPass = subTimeTest && addressTest;
 
-        lists.getByCid(req.params.cid, (err, list) => {
+        lists.getByCidOrName(req.params.cid, (err, list) => {
             if (!err) {
                 if (!list) {
                     err = new Error(_('Selected list not found'));
@@ -454,7 +454,7 @@ router.post('/:cid/subscribe', passport.parseForm, corsOrCsrfProtection, (req, r
 });
 
 router.get('/:lcid/manage/:ucid', passport.csrfProtection, (req, res, next) => {
-    lists.getByCid(req.params.lcid, (err, list) => {
+    lists.getByCidOrName(req.params.lcid, (err, list) => {
         if (!err && !list) {
             err = new Error(_('Selected list not found'));
             err.status = 404;
@@ -530,7 +530,7 @@ router.get('/:lcid/manage/:ucid', passport.csrfProtection, (req, res, next) => {
 });
 
 router.post('/:lcid/manage', passport.parseForm, passport.csrfProtection, (req, res, next) => {
-    lists.getByCid(req.params.lcid, (err, list) => {
+    lists.getByCidOrName(req.params.lcid, (err, list) => {
         if (!err && !list) {
             err = new Error(_('Selected list not found'));
             err.status = 404;
@@ -561,7 +561,7 @@ router.post('/:lcid/manage', passport.parseForm, passport.csrfProtection, (req, 
 });
 
 router.get('/:lcid/manage-address/:ucid', passport.csrfProtection, (req, res, next) => {
-    lists.getByCid(req.params.lcid, (err, list) => {
+    lists.getByCidOrName(req.params.lcid, (err, list) => {
         if (!err && !list) {
             err = new Error(_('Selected list not found'));
             err.status = 404;
@@ -621,7 +621,7 @@ router.get('/:lcid/manage-address/:ucid', passport.csrfProtection, (req, res, ne
 });
 
 router.post('/:lcid/manage-address', passport.parseForm, passport.csrfProtection, (req, res, next) => {
-    lists.getByCid(req.params.lcid, (err, list) => {
+    lists.getByCidOrName(req.params.lcid, (err, list) => {
         if (!err && !list) {
             err = new Error(_('Selected list not found'));
             err.status = 404;
@@ -677,7 +677,7 @@ router.post('/:lcid/manage-address', passport.parseForm, passport.csrfProtection
 });
 
 router.get('/:lcid/unsubscribe/:ucid', passport.csrfProtection, (req, res, next) => {
-    lists.getByCid(req.params.lcid, (err, list) => {
+    lists.getByCidOrName(req.params.lcid, (err, list) => {
         if (!err && !list) {
             err = new Error(_('Selected list not found'));
             err.status = 404;
@@ -755,7 +755,7 @@ router.get('/:lcid/unsubscribe/:ucid', passport.csrfProtection, (req, res, next)
 });
 
 router.post('/:lcid/unsubscribe', passport.parseForm, passport.csrfProtection, (req, res, next) => {
-    lists.getByCid(req.params.lcid, (err, list) => {
+    lists.getByCidOrName(req.params.lcid, (err, list) => {
         if (!err && !list) {
             err = new Error(_('Selected list not found'));
             err.status = 404;
@@ -892,7 +892,7 @@ router.post('/publickey', passport.parseForm, (req, res, next) => {
 
 
 function webNotice(type, req, res, next) {
-    lists.getByCid(req.params.cid, (err, list) => {
+    lists.getByCidOrName(req.params.cid, (err, list) => {
         if (!err && !list) {
             err = new Error(_('Selected list not found'));
             err.status = 404;


### PR DESCRIPTION
List CIDs are unpredictable, can only be created at runtime, and currently there isn't an API endpoint to GET them for REST clients. We are integrating with Mailtrain's REST API and this became a problem, especially for our automated tests that need predictability, but also for automatic configuration of our production systems that shouldn't require human intervention.

Hence, this change adds support for calling the REST APIs using the list name as an option in addition to the CID.

We decided for this very simple solution, instead of just fixing the list GET endpoint and making two requests per use of the API, because this is much faster and simpler to use, and a collision of a list name and a CID is highly unlikely to happen.

PS. Following this we'll send in more PRs, APIs for automating list creation, and predictable access tokens