### PR TITLE
Bugfix: include list segment when saving in Mosaico

### DIFF
--- a/views/mosaico/editor.hbs
+++ b/views/mosaico/editor.hbs
@@ -111,7 +111,7 @@
                     $.post('/editorapi/update?type={{type}}&editor={{resource.editorName}}', {
                         id: {{resource.id}},
                         name: '{{resource.name}}',
-                        {{#if resource.list}} list: {{resource.list}}, {{/if}}
+                        {{#if resource.list}} list: {{resource.list}}+':'+{{resource.segment}}, {{/if}}
                         html: html,
                         editorData: JSON.stringify({
                             template: '{{resource.editorData.template}}',


### PR DESCRIPTION
Mosaico saves the campaign in such a way that only the list and not the list segment is updated. This leads to sending mails to the wrong addresses when the newsletter is edited while it is already being sent. To fix this, this pull request simply appends `:segment` in the `list` field posted to the `editorapi`.