### PR TITLE
Don't limit campaigns in triggers to 300

### DIFF
--- a/routes/triggers.js
+++ b/routes/triggers.js
@@ -112,7 +112,7 @@ router.get('/:listId/:segmentId/create', passport.csrfProtection, (req, res, nex
                         selected: data.column === field.column
                     }));
 
-                    campaigns.list(0, 300, (err, campaignList) => {
+                    campaigns.list(0, 0, (err, campaignList) => {
                         if (err) {
                             return next(err);
                         }
@@ -203,7 +203,7 @@ router.get('/edit/:id', passport.csrfProtection, (req, res, next) => {
                             fieldList = [];
                         }
 
-                        campaigns.list(0, 300, (err, campaignList) => {
+                        campaigns.list(0, 0, (err, campaignList) => {
                             if (err) {
                                 return next(err);
                             }


### PR DESCRIPTION
A client of mine had over 500 campaigns and they couldn't see the trigger campaigns when editting a trigger. `sourceCampaigns` didn't have all and `destCampaigns` was empty. This commit removes the limit from the query.