### PR TITLE
Added subscription changed trigger

### DIFF
--- a/client/src/campaigns/triggers/CUD.js
+++ b/client/src/campaigns/triggers/CUD.js
@@ -54,6 +54,7 @@ export default class CUD extends Component {
         this.eventOptions = {
             [Entity.SUBSCRIPTION]: [
                 {key: SubscriptionEvent.CREATED, label: eventLabels[Entity.SUBSCRIPTION][SubscriptionEvent.CREATED]},
+                {key: SubscriptionEvent.UPDATED, label: eventLabels[Entity.SUBSCRIPTION][SubscriptionEvent.UPDATED]},
                 {key: SubscriptionEvent.LATEST_OPEN, label: eventLabels[Entity.SUBSCRIPTION][SubscriptionEvent.LATEST_OPEN]},
                 {key: SubscriptionEvent.LATEST_CLICK, label: eventLabels[Entity.SUBSCRIPTION][SubscriptionEvent.LATEST_CLICK]}
             ],

--- a/client/src/campaigns/triggers/helpers.js
+++ b/client/src/campaigns/triggers/helpers.js
@@ -15,6 +15,7 @@ export function getTriggerTypes(t) {
     const eventLabels = {
         [Entity.SUBSCRIPTION]: {
             [SubscriptionEvent.CREATED]: t('created'),
+            [SubscriptionEvent.UPDATED]: t('updated'),
             [SubscriptionEvent.LATEST_OPEN]: t('latestOpen'),
             [SubscriptionEvent.LATEST_CLICK]: t('latestClick')
         },

--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -145,6 +145,7 @@
   "addList": "Add list",
   "type": "Type",
   "created": "Created",
+  "updated": "Updated",
   "override": "Override",
   "fromName": "\"From\" name",
   "fromEmailAddress": "\"From\" email address",

--- a/server/models/lists.js
+++ b/server/models/lists.js
@@ -195,6 +195,7 @@ async function create(context, entity) {
             '  `latest_open` timestamp NULL DEFAULT NULL,\n' +
             '  `latest_click` timestamp NULL DEFAULT NULL,\n' +
             '  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,\n' +
+            '  `updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,\n' +
             '  PRIMARY KEY (`id`),\n' +
             '  UNIQUE KEY `hash_email` (`hash_email`),\n' +
             '  UNIQUE KEY `cid` (`cid`),\n' +
@@ -204,7 +205,8 @@ async function create(context, entity) {
             '  KEY `is_test` (`is_test`),\n' +
             '  KEY `latest_open` (`latest_open`),\n' +
             '  KEY `latest_click` (`latest_click`),\n' +
-            '  KEY `created` (`created`)\n' +
+            '  KEY `created` (`created`),\n' +
+            '  KEY `updated` (`updated`)\n' +
             ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n');
 
         await shares.rebuildPermissionsTx(tx, { entityTypeId: 'list', entityId: id });

--- a/server/models/subscriptions.js
+++ b/server/models/subscriptions.js
@@ -616,6 +616,7 @@ async function _update(tx, listId, groupedFieldsMap, existing, filteredEntity) {
     }
 
     if (filteredEntity) {
+        filteredEntity.updated = new Date();
         await tx(getSubscriptionTableName(listId)).where('id', existing.id).update(filteredEntity);
 
         if ('status' in filteredEntity) {

--- a/server/setup/knex/migrations/20191007120000_add_updated_to_subscriptions.js
+++ b/server/setup/knex/migrations/20191007120000_add_updated_to_subscriptions.js
@@ -1,0 +1,10 @@
+exports.up = (knex, Promise) => (async() => {
+    const lists = await knex('lists');
+    for (const list of lists) {
+        await knex.schema.raw('ALTER TABLE `subscription__' + list.id + '` ADD COLUMN `updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `created`');
+        await knex.schema.raw('CREATE INDEX updated ON `subscription__' + list.id + '` (`updated`)');
+    }
+})();
+
+exports.down = (knex, Promise) => (async() => {
+})();

--- a/shared/triggers.js
+++ b/shared/triggers.js
@@ -8,6 +8,7 @@ const Entity = {
 const Event = {
     [Entity.SUBSCRIPTION]: {
         CREATED: 'created',
+        UPDATED: 'updated',
         LATEST_OPEN: 'latest_open',
         LATEST_CLICK: 'latest_click'
     },
@@ -28,6 +29,7 @@ const EntityVals = {
 const EventVals = {
     [Entity.SUBSCRIPTION]: {
         created: 'CREATED',
+        updated: 'UPDATED',
         latest_open: 'LATEST_OPEN',
         latest_click: 'LATEST_CLICK'
     },


### PR DESCRIPTION
Is very useful if some subscription data is updated by API and you want to trigger after that because segments (filters - #722) have changed.