### PR TITLE
Report triggered campaign messages & fix trigger of trigger

### DIFF
--- a/server/lib/message-sender.js
+++ b/server/lib/message-sender.js
@@ -579,6 +579,16 @@ async function sendQueuedMessage(queuedMessage) {
     }
 
     if (messageType === MessageType.TRIGGERED) {
+        await knex.raw(knex('campaign_messages').insert({
+            campaign: campaign.id,
+            list: result.list.id,
+            subscription: result.subscriptionGrouped.id,
+            send_configuration: queuedMessage.send_configuration,
+            status: CampaignMessageStatus.SENT,
+            response: result.response,
+            response_id: result.response_id,
+            hash_email: result.subscriptionGrouped.hash_email
+        }).toString().replace(/^insert/i, 'insert ignore'));
         await knex('campaigns').where('id', campaign.id).increment('delivered');
     }
 


### PR DESCRIPTION
This fixes that triggered campaign e-mails are not reported in ui and so it's also possible to
create another triggered campaign on this first triggered one.

What i don't understand why their is a difference in handling of a triggered campaign and a normal one in sending.

Also i expected that a triggered campaign can only be send once to an user regardless which trigger fires the send.
But currently it's send for every trigger that is defined in a campaign.