### PR TITLE
Updated with support for link wrapping in URL camp

### DIFF
--- a/server/lib/message-sender.js
+++ b/server/lib/message-sender.js
@@ -214,7 +214,7 @@ class MessageSender {
 
             html = response.body;
             text = '';
-            renderTags = false;
+            renderTags = true;
         }
 
         const attachments = this.attachments.slice();
@@ -236,8 +236,10 @@ class MessageSender {
                 html = await links.updateLinks(html, this.tagLanguage, mergeTags, campaign, list, subscriptionGrouped);
             }
 
-            // When no list and subscriptionGrouped is provided, formatCampaignTemplate works the same way as formatTemplate
-            html = tools.formatCampaignTemplate(html, this.tagLanguage, mergeTags, true, campaign, list, subscriptionGrouped);
+            if (campaign.source !== CampaignSource.URL) {
+              // When no list and subscriptionGrouped is provided, formatCampaignTemplate works the same way as formatTemplate
+              html = tools.formatCampaignTemplate(html, this.tagLanguage, mergeTags, true, campaign, list, subscriptionGrouped);
+            }
         }
 
         const generateText = !!(text || '').trim();

--- a/server/models/links.js
+++ b/server/models/links.js
@@ -140,7 +140,7 @@ async function addOrGet(campaignId, url) {
     }
 }
 
-async function updateLinks(source, tagLanguage, mergeTags, campaign, list, subscription) {
+async function updateLinks(source, tagLanguage='simple', mergeTags, campaign, list, subscription) {
     if ((campaign.open_tracking_disabled && campaign.click_tracking_disabled) || !source || !source.trim()) {
         // tracking is disabled, do not modify the message
         return source;


### PR DESCRIPTION
I've added support here to make sure that links and email opens get tracked when using the URL campaign content source.