### PR TITLE
Fix rendering of access token in API docs

### DIFF
--- a/client/src/account/API.js
+++ b/client/src/account/API.js
@@ -292,7 +292,7 @@ export default class API extends Component {
                     <strong>{t('example')}</strong>
                 </p>
 
-                <pre>curl -XPOST '{getUrl(`api/blacklist/add?access_token={accessToken}`)}' \<br/>
+                <pre>curl -XPOST '{getUrl(`api/blacklist/add?access_token=${accessToken}`)}' \<br/>
 --data 'EMAIL=test@example.com&amp;'</pre>
 
                 <h4>POST /api/blacklist/delete – {t('deleteEmailFromBlacklist')}</h4>

--- a/client/src/account/API.js
+++ b/client/src/account/API.js
@@ -293,7 +293,7 @@ export default class API extends Component {
                 </p>
 
                 <pre>curl -XPOST '{getUrl(`api/blacklist/add?access_token=${accessToken}`)}' \<br/>
---data 'EMAIL=test@example.com&amp;'</pre>
+--data 'EMAIL=test@example.com'</pre>
 
                 <h4>POST /api/blacklist/delete – {t('deleteEmailFromBlacklist')}</h4>
 
@@ -320,7 +320,7 @@ export default class API extends Component {
                 </p>
 
                 <pre>curl -XPOST '{getUrl(`api/blacklist/delete?access_token=${accessToken}`)}' \<br/>
---data 'EMAIL=test@example.com&amp;'</pre>
+--data 'EMAIL=test@example.com'</pre>
 
                 <h4>GET /api/lists/:email – {t('getTheListsAUserHasSubscribedTo')}</h4>
 


### PR DESCRIPTION
...and remove trailing `&amp;`s.

#### Before:
![Screenshot_20191110_003922](https://user-images.githubusercontent.com/5571650/68536395-90d06700-0352-11ea-8978-b3da2b70efb6.png)

#### After:
![Screenshot_20191110_003733](https://user-images.githubusercontent.com/5571650/68536382-4cdd6200-0352-11ea-8f92-e3fff5ba749c.png)