### PR TITLE
Add Field `cid` to `/api/lists/:email`

### DIFF
--- a/server/models/subscriptions.js
+++ b/server/models/subscriptions.js
@@ -863,7 +863,7 @@ async function getListsWithEmail(context, email) {
     // FIXME - this methods is rather suboptimal if there are many lists. It quite needs permission caching in shares.js
 
     return await knex.transaction(async tx => {
-        const lsts = await tx('lists').select(['id', 'name']);
+        const lsts = await tx('lists').select(['id', 'cid', 'name']);
         const result = [];
 
         for (const list of lsts) {


### PR DESCRIPTION
With this `cid` you are able to do further API calls like unsubscribing the user from all mailing lists.

Maybe it would be useful to add a separated API endpoint for that to streamline the calls.

#### Example response before:

```json
{
    "data": [
        {
            "id": 1,
            "name": "Test List"
        }
    ]
}
```

#### Example response after:

```json
{
    "data": [
        {
            "cid": "1-oXzj0Kw",
            "id": 1,
            "name": "Test List"
        }
    ]
}
````