### PR TITLE
V2: Return external ID (cid) in /api/lists/:email endpoint

### DIFF
--- a/server/models/subscriptions.js
+++ b/server/models/subscriptions.js
@@ -863,7 +863,7 @@ async function getListsWithEmail(context, email) {
     // FIXME - this methods is rather suboptimal if there are many lists. It quite needs permission caching in shares.js
 
     return await knex.transaction(async tx => {
-        const lsts = await tx('lists').select(['id', 'name']);
+        const lsts = await tx('lists').select(['cid', 'id', 'name']);
         const result = [];
 
         for (const list of lsts) {


### PR DESCRIPTION
Add *cid* to the list of fields returned per list for the */api/lists/:email* endpoint. This allows the response to be used for further api calls like updating a subscription, etc.

I kept *id* in the response for backwards compatibility.