### PR TITLE
Override config for docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,26 @@ The instructions above use an automatically built Docker image on DockerHub (htt
 | LDAP_BASEDN      | LDAP base DN                                                          |
 | LDAP_UIDTAG      | LDAP UID tag (e.g. uid/cn/username)                                   |
 
+If you are using docker-compose to run Mailtrain in production and need to pass your own overrides of these env-vars in a custom override like `docker-compose.override.yml`:
+
+```
+version: '3'
+services:
+  mailtrain:
+    environment:
+    - URL_BASE_TRUSTED
+    - URL_BASE_SANDBOX
+    - URL_BASE_PUBLIC
+```
+
+You can now override URL_BASE_TRUSTED, URL_BASE_SANDBOX and URL_BASE_PUBLIC in an `.env` file and run this command to build or run it
+
+`docker-compose -f docker-compose.yml -f docker-compose.override.yml build (or up)`
+
+or you can pass this env-vars in the shell-command like this
+
+`URL_BASE_TRUSTED=https://mailtrain.domain.com (and more env-vars..) docker-compose -f docker-compose.yml -f docker-compose.override.yml build (or up)`
+
 ## License
 
   **GPL-V3.0**

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -37,7 +37,7 @@ else
     echo 'Info: Generating application/production.yaml'
 
     # Basic configuration
-    cat > server/config/production.yaml <<EOT
+    cat >> server/config/production.yaml <<EOT
 www:
   host: 0.0.0.0
   proxy: $WWW_PROXY
@@ -55,9 +55,6 @@ mysql:
 redis:
   enabled: true
   host: $REDIS_HOST
-
-log:
-  level: info
 
 builtinZoneMTA:
   log:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,57 +38,57 @@ else
 
     # Basic configuration
     cat > server/config/production.yaml <<EOT
-    www:
-      host: 0.0.0.0
-      proxy: $WWW_PROXY
-      secret: "`pwgen -1`"
-      trustedUrlBase: $URL_BASE_TRUSTED
-      sandboxUrlBase: $URL_BASE_SANDBOX
-      publicUrlBase: $URL_BASE_PUBLIC
+www:
+  host: 0.0.0.0
+  proxy: $WWW_PROXY
+  secret: "`pwgen -1`"
+  trustedUrlBase: $URL_BASE_TRUSTED
+  sandboxUrlBase: $URL_BASE_SANDBOX
+  publicUrlBase: $URL_BASE_PUBLIC
 
-    mysql:
-      host: $MYSQL_HOST
-      database: $MYSQL_DATABASE
-      user: $MYSQL_USER
-      password: $MYSQL_PASSWORD
+mysql:
+  host: $MYSQL_HOST
+  database: $MYSQL_DATABASE
+  user: $MYSQL_USER
+  password: $MYSQL_PASSWORD
 
-    redis:
-      enabled: true
-      host: $REDIS_HOST
+redis:
+  enabled: true
+  host: $REDIS_HOST
 
-    log:
-      level: info
+log:
+  level: info
 
-    builtinZoneMTA:
-      log:
-        level: warn
-      mongo: mongodb://${MONGO_HOST}:27017/zone-mta
-      redis: redis://${REDIS_HOST}:6379/2
+builtinZoneMTA:
+  log:
+    level: warn
+  mongo: mongodb://${MONGO_HOST}:27017/zone-mta
+  redis: redis://${REDIS_HOST}:6379/2
 
-    queue:
-      processes: 5
+queue:
+  processes: 5
 EOT
 
     # Manage LDAP if enabled
     if [ "$WITH_LDAP" = "true" ]; then
         echo 'Info: LDAP enabled'
     cat >> server/config/production.yaml <<EOT
-    ldap:
-      enabled: true
-      host: $LDAP_HOST
-      port: $LDAP_PORT
-      secure: $LDAP_SECURE
-      bindUser: $LDAP_BIND_USER
-      bindPasswort: $LDAP_BIND_PASS
-      filter: $LDAP_FILTER
-      baseDN: $LDAP_BASEDN
-      uidTag: $LDAP_UIDTAG
+ldap:
+  enabled: true
+  host: $LDAP_HOST
+  port: $LDAP_PORT
+  secure: $LDAP_SECURE
+  bindUser: $LDAP_BIND_USER
+  bindPasswort: $LDAP_BIND_PASS
+  filter: $LDAP_FILTER
+  baseDN: $LDAP_BASEDN
+  uidTag: $LDAP_UIDTAG
 EOT
     else
         echo 'Info: LDAP not enabled'
     cat >> server/config/production.yaml <<EOT
-    ldap:
-      enabled: false
+ldap:
+  enabled: false
 EOT
     fi
 
@@ -99,10 +99,10 @@ if [ -f server/services/workers/reports/config/production.yaml ]; then
 else
     echo 'Info: Generating server/production.yaml'
     cat > server/services/workers/reports/config/production.yaml <<EOT
-    mysql:
-      host: $MYSQL_HOST
-    log:
-      level: warn
+mysql:
+  host: $MYSQL_HOST
+log:
+  level: warn
 EOT
 fi
 


### PR DESCRIPTION
Adjustments for docker-entrypoint.sh to be able to add own server/config/production.yaml when building an own image of mailtrain, and some notes about passing env-vars into docker-images after #783 