### PR TITLE
Fix import of date and general handle of mysql-dates in docker

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -10,6 +10,7 @@ services:
     - MYSQL_PASSWORD=mailtrain
     volumes:
     - mysql-data:/var/lib/mysql
+    command: mysqld --sql_mode=""
 
   redis:
     image: redis:5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     - MYSQL_PASSWORD=mailtrain
     volumes:
     - mysql-data:/var/lib/mysql
+    command: mysqld --sql_mode=""
 
   redis:
     image: redis:5

--- a/server/models/fields.js
+++ b/server/models/fields.js
@@ -310,7 +310,12 @@ async function listTx(tx, listId) {
 async function list(context, listId) {
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'list', listId, ['viewFields']);
-        return await listTx(tx, listId);
+        const flds = await listTx(tx, listId);
+
+        return flds.map(fld => {
+            fld.settings = JSON.parse(fld.settings);
+            return fld;
+        });
     });
 }
 


### PR DESCRIPTION
Need to parse the fields settings to make the date-format available in parsing, and set sql_mode in docker to make dates work even if they are not strict mysql-dates