### PR TITLE
Handle failures from AWS SES

### DIFF
--- a/server/lib/message-sender.js
+++ b/server/lib/message-sender.js
@@ -516,7 +516,10 @@ class MessageSender {
         try {
             result = await this._sendMessage({listId: campaignMessage.list, subscriptionId: campaignMessage.subscription});
         } catch (err) {
-            if (err.campaignMessageErrorType === CampaignMessageErrorType.PERMANENT) {
+            if (
+              err.campaignMessageErrorType === CampaignMessageErrorType.PERMANENT ||
+              err.retryable === false
+            ) {
               await knex('campaign_messages')
                 .where({id: campaignMessage.id})
                 .update({


### PR DESCRIPTION
If a message fail to be delivered by AWS SES check if retryable is set to false to abort new retries. Else mailtrain will continue to try to deliver it until retention level is reach for campaign (default to 1 day)