### PR TITLE
Add possibility to set pool name for builtin ZoneMTA.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The instructions above use an automatically built Docker image on DockerHub (htt
 | LDAP_FILTER      | LDAP filter                                                           |
 | LDAP_BASEDN      | LDAP base DN                                                          |
 | LDAP_UIDTAG      | LDAP UID tag (e.g. uid/cn/username)                                   |
+| POOL_NAME        | sets builtin Zone-MTA pool name (default: os.hostname())              |
 
 ## License
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,6 +22,7 @@ MYSQL_HOST=${MYSQL_HOST:-'mysql'}
 MYSQL_DATABASE=${MYSQL_DATABASE:-'mailtrain'}
 MYSQL_USER=${MYSQL_USER:-'mailtrain'}
 MYSQL_PASSWORD=${MYSQL_PASSWORD:-'mailtrain'}
+POOL_NAME=${POOL_NAME:-$(hostname)}
 
 # Warning for users that already rely on the MAILTRAIN_SETTING variable
 # Can probably be removed in the future.
@@ -64,6 +65,7 @@ else
         level: warn
       mongo: mongodb://${MONGO_HOST}:27017/zone-mta
       redis: redis://${REDIS_HOST}:6379/2
+      poolName: $POOL_NAME
 
     queue:
       processes: 5

--- a/docs/README.md
+++ b/docs/README.md
@@ -116,6 +116,8 @@ If you do not use VERP with ZoneMTA then you should get notified most of the bou
 
 If you are using the bundled ZoneMTA then you should make sure you are using a proper PTR record for your server. For example if you use DigitalOcean then PTR is set automatically (it's the droplet name, so make sure your droplet name is the same as the domain name you are running Mailtrain from). If you use AWS then you can request setting up PTR records using [this form](https://portal.aws.amazon.com/gp/aws/html-forms-controller/contactus/ec2-email-limit-rdns-request) (requires authentication). Otherwise you would have to check from your service provider, hot to get the PTR record changed. Everything should work without the PTR record but setting it up correctly improves the deliverability a lot.
 
+If you are using the builtin Zone-MTA, make sure the configured pool name matches the PTR record.
+
 ##### 7. Ready to send!
 
 With proper SPF, DKIM and PTR records (DMARC wouldn't hurt either) I got perfect 10/10 score out from [MailTester](https://www.mail-tester.com/) when sending a campaign message to a MailTester test address. I did not have VERP turned on, so the sender address matched return path address.

--- a/server/config/default.yaml
+++ b/server/config/default.yaml
@@ -257,6 +257,7 @@ builtinZoneMTA:
     level: warn
   processes: 2
   connections: 5
+  # poolName: 'mail.example.com' # defaults to os.hostname()
 
 seleniumWebDriver:
   browser: phantomjs

--- a/server/lib/builtin-zone-mta.js
+++ b/server/lib/builtin-zone-mta.js
@@ -119,6 +119,13 @@ async function createConfig() {
             }
         },
 
+        pools: {
+            default: {
+              address: '0.0.0.0',
+              name: config.builtinZoneMTA.poolName || os.hostname()
+            }
+        },
+
         zones: {
             default: {
                 preferIPv6: false,


### PR DESCRIPTION
This PR adds the possibility to set the name of the ZoneMTA pool, such that a.o. HELO requests have the proper hostname.

By default, ZoneMTA creates a pool with the hostname of the system as pool name. This will not turn out very well inside docker containers and on kubernetes, as the hostnames will not be valid FQDNs outside the environment, resulting in failing spam scores. (https://github.com/zone-eu/zone-mta/issues/162 / https://github.com/Mailtrain-org/mailtrain/issues/768).

This is not a breaking change, as the poolName defaults to the hostname [as before](https://github.com/zone-eu/zone-mta/blob/d482f42b1294ef8d584e7f2ff75e3e95120e631b/config/default.js#L326).