### PR TITLE
Fix path to server config file.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ ! -z "$MAILTRAIN_SETTING" ]; then
     exit 1
 fi
 
-if [ -f application/config/config.php ]; then
+if [ -f server/config/production.yaml ]; then
     echo 'Info: application/production.yaml already provisioned'
 else
     echo 'Info: Generating application/production.yaml'


### PR DESCRIPTION
Without this, when the container is rebooted, its inserting again the configs in the yml file, causing a key duplication error when reading it.