### PR TITLE
Set more config options from docker-entrypoint.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,9 @@ variables (e.g. `URL_BASE_TRUSTED=https://mailtrain.domain.com (and more env-var
 | PORT_TRUSTED     | sets the trusted port of the instance (default: 3000)                 |
 | PORT_SANDBOX     | sets the sandbox port of the instance (default: 3003)                 |
 | PORT_PUBLIC      | sets the public port of the instance (default: 3004)                  |
-| URL_BASE_TRUSTED | sets the trusted url of the instance (default: http://localhost)      |
-| URL_BASE_SANDBOX | sets the sandbox url of the instance (default: http://localhost)      |
-| URL_BASE_PUBLIC  | sets the public url of the instance (default: http://localhost)       |
+| URL_BASE_TRUSTED | sets the trusted url of the instance (default: http://localhost:3000) |
+| URL_BASE_SANDBOX | sets the sandbox url of the instance (default: http://localhost:3003) |
+| URL_BASE_PUBLIC  | sets the public url of the instance (default: http://localhost:3004)  |
 | WWW_HOST         | sets the address that the server binds to (default: 0.0.0.0)          |
 | WWW_PROXY        | use if Mailtrain is behind an http reverse proxy (default: false)     |
 | WWW_SECRET       | sets the secret for the express session (default: `$(pwgen -1)`)      |

--- a/README.md
+++ b/README.md
@@ -210,9 +210,12 @@ variables (e.g. `URL_BASE_TRUSTED=https://mailtrain.domain.com (and more env-var
 
 | Parameter        | Description |
 | ---------        | ----------- |
-| URL_BASE_TRUSTED | sets the trusted url of the instance (default: http://localhost:3000) |
-| URL_BASE_SANDBOX | sets the sandbox url of the instance (default: http://localhost:3003) |
-| URL_BASE_PUBLIC  | sets the public url of the instance (default: http://localhost:3004)  |
+| PORT_TRUSTED     | sets the trusted port of the instance (default: 3000)                 |
+| PORT_SANDBOX     | sets the sandbox port of the instance (default: 3003)                 |
+| PORT_PUBLIC      | sets the public port of the instance (default: 3004)                  |
+| URL_BASE_TRUSTED | sets the trusted url of the instance (default: http://localhost)      |
+| URL_BASE_SANDBOX | sets the sandbox url of the instance (default: http://localhost)      |
+| URL_BASE_PUBLIC  | sets the public url of the instance (default: http://localhost)       |
 | WWW_HOST         | sets the address that the server binds to (default: 0.0.0.0)          |
 | WWW_PROXY        | use if Mailtrain is behind an http reverse proxy (default: false)     |
 | WWW_SECRET       | sets the secret for the express session (default: `$(pwgen -1)`)      |

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ variables (e.g. `URL_BASE_TRUSTED=https://mailtrain.domain.com (and more env-var
 | WWW_PROXY        | use if Mailtrain is behind an http reverse proxy (default: false)     |
 | WWW_SECRET       | sets the secret for the express session (default: `$(pwgen -1)`)      |
 | MONGO_HOST       | sets mongo host (default: mongo)                                      |
+| WITH_REDIS       | enables or disables redis (default: true)                             |
 | REDIS_HOST       | sets redis host (default: redis)                                      |
 | MYSQL_HOST       | sets mysql host (default: mysql)                                      |
 | MYSQL_DATABASE   | sets mysql database (default: mailtrain)                              |
@@ -234,6 +235,7 @@ variables (e.g. `URL_BASE_TRUSTED=https://mailtrain.domain.com (and more env-var
 | LDAP_FILTER      | LDAP filter                                                           |
 | LDAP_BASEDN      | LDAP base DN                                                          |
 | LDAP_UIDTAG      | LDAP UID tag (e.g. uid/cn/username)                                   |
+| WITH_ZONE_MTA    | enables or disables builtin Zone-MTA (default: true)                  |
 | POOL_NAME        | sets builtin Zone-MTA pool name (default: os.hostname())              |
 
 If you don't want to modify the original `docker-compose.yml`, you can put your overrides to another file (e.g. `docker-compose.override.yml`) -- like the one below.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ variables (e.g. `URL_BASE_TRUSTED=https://mailtrain.domain.com (and more env-var
 | URL_BASE_TRUSTED | sets the trusted url of the instance (default: http://localhost:3000) |
 | URL_BASE_SANDBOX | sets the sandbox url of the instance (default: http://localhost:3003) |
 | URL_BASE_PUBLIC  | sets the public url of the instance (default: http://localhost:3004)  |
+| WWW_HOST         | sets the address that the server binds to (default: 0.0.0.0)          |
 | WWW_PROXY        | use if Mailtrain is behind an http reverse proxy (default: false)     |
+| WWW_SECRET       | sets the secret for the express session (default: `$(pwgen -1)`)      |
 | MONGO_HOST       | sets mongo host (default: mongo)                                      |
 | REDIS_HOST       | sets redis host (default: redis)                                      |
 | MYSQL_HOST       | sets mysql host (default: mysql)                                      |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,9 @@ default_filter="(|(username={{username}})(mail={{username}}))"
 URL_BASE_TRUSTED=${URL_BASE_TRUSTED:-'http://localhost:3000'}
 URL_BASE_SANDBOX=${URL_BASE_SANDBOX:-'http://localhost:3003'}
 URL_BASE_PUBLIC=${URL_BASE_PUBLIC:-'http://localhost:3004'}
+WWW_HOST=${WWW_HOST:-'0.0.0.0'}
 WWW_PROXY=${WWW_PROXY:-'false'}
+WWW_SECRET=${WWW_SECRET:-$(pwgen -1)}
 WITH_LDAP=${WITH_LDAP:-'false'}
 LDAP_HOST=${LDAP_HOST:-'ldap'}
 LDAP_PORT=${LDAP_PORT:-'389'}
@@ -45,9 +47,9 @@ else
     # Basic configuration
     cat >> server/config/production.yaml <<EOT
 www:
-  host: 0.0.0.0
+  host: $WWW_HOST
   proxy: $WWW_PROXY
-  secret: "`pwgen -1`"
+  secret: $WWW_SECRET
   trustedUrlBase: $URL_BASE_TRUSTED
   sandboxUrlBase: $URL_BASE_SANDBOX
   publicUrlBase: $URL_BASE_PUBLIC

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,11 +27,13 @@ LDAP_MAILTAG=${LDAP_MAILTAG:-'mail'}
 LDAP_NAMETAG=${LDAP_NAMETAG:-'username'}
 LDAP_METHOD=${LDAP_METHOD:-'ldapjs'}
 MONGO_HOST=${MONGO_HOST:-'mongo'}
+WITH_REDIS=${WITH_REDIS:-'true'}
 REDIS_HOST=${REDIS_HOST:-'redis'}
 MYSQL_HOST=${MYSQL_HOST:-'mysql'}
 MYSQL_DATABASE=${MYSQL_DATABASE:-'mailtrain'}
 MYSQL_USER=${MYSQL_USER:-'mailtrain'}
 MYSQL_PASSWORD=${MYSQL_PASSWORD:-'mailtrain'}
+WITH_ZONE_MTA=${WITH_ZONE_MTA:-'true'}
 POOL_NAME=${POOL_NAME:-$(hostname)}
 
 # Warning for users that already rely on the MAILTRAIN_SETTING variable
@@ -67,10 +69,11 @@ mysql:
   password: $MYSQL_PASSWORD
 
 redis:
-  enabled: true
+  enabled: $WITH_REDIS
   host: $REDIS_HOST
 
 builtinZoneMTA:
+  enabled: $WITH_ZONE_MTA
   log:
     level: warn
   mongo: mongodb://${MONGO_HOST}:27017/zone-mta
@@ -125,11 +128,15 @@ fi
 echo 'Info: Waiting for MySQL Server'
 while ! nc -z $MYSQL_HOST 3306; do sleep 1; done
 
-echo 'Info: Waiting for Redis Server'
-while ! nc -z $REDIS_HOST 6379; do sleep 1; done
+if [ "$WITH_REDIS" = "true" ]; then
+  echo 'Info: Waiting for Redis Server'
+  while ! nc -z $REDIS_HOST 6379; do sleep 1; done
+fi
 
-echo 'Info: Waiting for MongoDB Server'
-while ! nc -z $MONGO_HOST 27017; do sleep 1; done
+if [ "$WITH_ZONE_MTA" = "true" ]; then
+  echo 'Info: Waiting for MongoDB Server'
+  while ! nc -z $MONGO_HOST 27017; do sleep 1; done
+fi
 
 cd server
 NODE_ENV=production node index.js

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,9 +5,12 @@ set -e
 
 default_filter="(|(username={{username}})(mail={{username}}))"
 
-URL_BASE_TRUSTED=${URL_BASE_TRUSTED:-'http://localhost:3000'}
-URL_BASE_SANDBOX=${URL_BASE_SANDBOX:-'http://localhost:3003'}
-URL_BASE_PUBLIC=${URL_BASE_PUBLIC:-'http://localhost:3004'}
+URL_BASE_TRUSTED=${URL_BASE_TRUSTED:-'http://localhost'}
+URL_BASE_SANDBOX=${URL_BASE_SANDBOX:-'http://localhost'}
+URL_BASE_PUBLIC=${URL_BASE_PUBLIC:-'http://localhost'}
+PORT_TRUSTED=${PORT_TRUSTED:-'3000'}
+PORT_SANDBOX=${PORT_SANDBOX:-'3003'}
+PORT_PUBLIC=${PORT_PUBLIC:-'3004'}
 WWW_HOST=${WWW_HOST:-'0.0.0.0'}
 WWW_PROXY=${WWW_PROXY:-'false'}
 WWW_SECRET=${WWW_SECRET:-$(pwgen -1)}
@@ -50,9 +53,12 @@ www:
   host: $WWW_HOST
   proxy: $WWW_PROXY
   secret: $WWW_SECRET
-  trustedUrlBase: $URL_BASE_TRUSTED
-  sandboxUrlBase: $URL_BASE_SANDBOX
-  publicUrlBase: $URL_BASE_PUBLIC
+  trustedPort: $PORT_TRUSTED
+  sandboxPort: $PORT_SANDBOX
+  publicPort: $PORT_PUBLIC
+  trustedUrlBase: $URL_BASE_TRUSTED:${PORT_TRUSTED}
+  sandboxUrlBase: $URL_BASE_SANDBOX:${PORT_SANDBOX}
+  publicUrlBase: $URL_BASE_PUBLIC:${PORT_PUBLIC}
 
 mysql:
   host: $MYSQL_HOST

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,12 +5,12 @@ set -e
 
 default_filter="(|(username={{username}})(mail={{username}}))"
 
-URL_BASE_TRUSTED=${URL_BASE_TRUSTED:-'http://localhost'}
-URL_BASE_SANDBOX=${URL_BASE_SANDBOX:-'http://localhost'}
-URL_BASE_PUBLIC=${URL_BASE_PUBLIC:-'http://localhost'}
 PORT_TRUSTED=${PORT_TRUSTED:-'3000'}
 PORT_SANDBOX=${PORT_SANDBOX:-'3003'}
 PORT_PUBLIC=${PORT_PUBLIC:-'3004'}
+URL_BASE_TRUSTED=${URL_BASE_TRUSTED:-"http://localhost:${PORT_TRUSTED}"}
+URL_BASE_SANDBOX=${URL_BASE_SANDBOX:-"http://localhost:${PORT_SANDBOX}"}
+URL_BASE_PUBLIC=${URL_BASE_PUBLIC:-"http://localhost:${PORT_PUBLIC}"}
 WWW_HOST=${WWW_HOST:-'0.0.0.0'}
 WWW_PROXY=${WWW_PROXY:-'false'}
 WWW_SECRET=${WWW_SECRET:-$(pwgen -1)}
@@ -58,9 +58,9 @@ www:
   trustedPort: $PORT_TRUSTED
   sandboxPort: $PORT_SANDBOX
   publicPort: $PORT_PUBLIC
-  trustedUrlBase: $URL_BASE_TRUSTED:${PORT_TRUSTED}
-  sandboxUrlBase: $URL_BASE_SANDBOX:${PORT_SANDBOX}
-  publicUrlBase: $URL_BASE_PUBLIC:${PORT_PUBLIC}
+  trustedUrlBase: $URL_BASE_TRUSTED
+  sandboxUrlBase: $URL_BASE_SANDBOX
+  publicUrlBase: $URL_BASE_PUBLIC
 
 mysql:
   host: $MYSQL_HOST


### PR DESCRIPTION
This PR makes the docker entry point use the following new environment variables to set the production config:

| Parameter        | Description |
| ---------        | ----------- |
| PORT_TRUSTED     | sets the trusted port of the instance (default: 3000)                 |
| PORT_SANDBOX     | sets the sandbox port of the instance (default: 3003)                 |
| PORT_PUBLIC      | sets the public port of the instance (default: 3004)                  |
| WWW_HOST         | sets the address that the server binds to (default: 0.0.0.0)          |
| WWW_SECRET       | sets the secret for the express session (default: `$(pwgen -1)`)      |
| WITH_REDIS       | enables or disables redis (default: true)                             |
| WITH_ZONE_MTA    | enables or disables builtin Zone-MTA (default: true)                  |

Edit:

~~This changes the expected values of the `URL_BASE_*` variables so that they should exlude the ports which are now gotten from the `PORT_*` variables~~

Re: https://github.com/Mailtrain-org/mailtrain/issues/505#issuecomment-578184150

:heart: 