### PR TITLE
Update subscription widget docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -234,21 +234,21 @@ Edit [mailtrain.conf](setup/mailtrain.conf) (update application folder) and copy
 
 The (experimental) Mailtrain Subscription Widget allows you to embed your sign-up forms on your website. To embed a Widget, you need to:
 
-Enable cross-origin resource sharing in your `config` file and whitelist your site:
+Enable cross-origin resource sharing in your `server/config/local.yaml` file (you may need to create it if it doesn't exist) and whitelist your site:
 
 ```
-[cors]
-# Allow subscription widgets to be embedded
-origins=['https://www.example.com']
+cors:
+  # Allow subscription widgets to be embedded
+  origins=['https://www.example.com']
 ```
 
-Embed the widget code on your website:
+Embed the widget code on your website using the untrusted endpoint:
 
 ```
-<div data-mailtrain-subscription-widget data-url="http://domain/subscription/Byf44R-og/widget">
-    <a href="http://domain/subscription/Byf44R-og">Subscribe to our list</a>
+<div data-mailtrain-subscription-widget data-url="http://lists.example.com/subscription/Byf44R-og/widget">
+    <a href="http://lists.example.com/subscription/Byf44R-og">Subscribe to our list</a>
 </div>
-<script src="http://domain/subscription/widget.js"></script>
+<script src="http://lists.example.com/static/subscription/widget.js"></script>
 ```
 
 ## Cloudron


### PR DESCRIPTION
The existing docs for the subscription widget are either vague (using `domain` instead of pointing out you should use the untrusted endpoint [which should be obvious]) or incorrect (missing `/static` when getting `widget.js`)