### PR TITLE
fix for 'shortid not defined'

### DIFF
--- a/server/lib/message-sender.js
+++ b/server/lib/message-sender.js
@@ -24,6 +24,7 @@ const blacklist = require('../models/blacklist');
 const libmime = require('libmime');
 const { enforce, hashEmail } = require('./helpers');
 const senders = require('./senders');
+const shortid = require('shortid');
 
 const MessageType = {
     REGULAR: 0,


### PR DESCRIPTION
Fixes following error:
```
 ERR! Senders Sending message to 4:1 failed with error: shortid is not defined. Dropping the message.
 verb ReferenceError: shortid is not defined
     at html.replace (/home/mailtrain2/mailtrain/server/lib/message-sender.js:236:29)
     at String.replace (<anonymous>)
     at MessageSender._getMessage (/home/mailtrain2/mailtrain/server/lib/message-sender.js:235:25)
     at MessageSender._sendMessage (/home/mailtrain2/mailtrain/server/lib/message-sender.js:345:34)
```