### PR TITLE
Add SES Regions and default SES Set Name to settings.

### DIFF
--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -169,7 +169,7 @@ function getTemplate(template, callback) {
 }
 
 function createMailer(callback) {
-    settings.list(['smtpHostname', 'smtpPort', 'smtpEncryption', 'smtpUser', 'smtpPass', 'smtpLog', 'smtpDisableAuth', 'smtpMaxConnections', 'smtpMaxMessages', 'smtpSelfSigned', 'pgpPrivateKey', 'pgpPassphrase', 'smtpThrottling', 'mailTransport', 'sesKey', 'sesSecret', 'sesRegion'], (err, configItems) => {
+    settings.list(['smtpHostname', 'smtpPort', 'smtpEncryption', 'smtpUser', 'smtpPass', 'smtpLog', 'smtpDisableAuth', 'smtpMaxConnections', 'smtpMaxMessages', 'smtpSelfSigned', 'pgpPrivateKey', 'pgpPassphrase', 'smtpThrottling', 'mailTransport', 'sesKey', 'sesSecret', 'sesRegion', 'sesDefaultSetName'], (err, configItems) => {
         if (err) {
             return callback(err);
         }
@@ -227,7 +227,8 @@ function createMailer(callback) {
                     apiVersion: '2010-12-01',
                     accessKeyId: configItems.sesKey,
                     secretAccessKey: configItems.sesSecret,
-                    region: configItems.sesRegion
+                    region: configItems.sesRegion,
+                    params: {ConfigurationSetName: configItems.sesDefaultSetName}
                 }),
                 debug: !!configItems.smtpLog,
                 logger: !configItems.smtpLog ? false : {

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -16,7 +16,7 @@ let _ = require('../lib/translate')._;
 
 let settings = require('../lib/models/settings');
 
-let allowedKeys = ['service_url', 'smtp_hostname', 'smtp_port', 'smtp_encryption', 'smtp_disable_auth', 'smtp_user', 'smtp_pass', 'admin_email', 'smtp_log', 'smtp_max_connections', 'smtp_max_messages', 'smtp_self_signed', 'default_from', 'default_address', 'default_subject', 'default_homepage', 'default_postaddress', 'default_sender', 'verp_hostname', 'verp_use', 'disable_wysiwyg', 'pgp_private_key', 'pgp_passphrase', 'ua_code', 'shoutout', 'disable_confirmations', 'smtp_throttling', 'dkim_api_key', 'dkim_private_key', 'dkim_selector', 'dkim_domain', 'mail_transport', 'ses_key', 'ses_secret', 'ses_region', 'x_mailer', 'default_unsubscribe'];
+let allowedKeys = ['service_url', 'smtp_hostname', 'smtp_port', 'smtp_encryption', 'smtp_disable_auth', 'smtp_user', 'smtp_pass', 'admin_email', 'smtp_log', 'smtp_max_connections', 'smtp_max_messages', 'smtp_self_signed', 'default_from', 'default_address', 'default_subject', 'default_homepage', 'default_postaddress', 'default_sender', 'verp_hostname', 'verp_use', 'disable_wysiwyg', 'pgp_private_key', 'pgp_passphrase', 'ua_code', 'shoutout', 'disable_confirmations', 'smtp_throttling', 'dkim_api_key', 'dkim_private_key', 'dkim_selector', 'dkim_domain', 'mail_transport', 'ses_key', 'ses_secret', 'ses_region', 'ses_default_set_name', 'x_mailer', 'default_unsubscribe'];
 
 router.all('/*', (req, res, next) => {
     if (!req.user) {
@@ -61,6 +61,34 @@ router.get('/', passport.csrfProtection, (req, res, next) => {
             checked: configItems.sesRegion === 'eu-west-1',
             key: 'eu-west-1',
             value: 'EU-WEST-1'
+        }, {
+            checked: configItems.sesRegion === 'eu-west-2',
+            key: 'eu-west-2',
+            value: 'EU-WEST-2'
+        }, {
+            checked: configItems.sesRegion === 'eu-central-1',
+            key: 'eu-central-1',
+            value: 'EU-CENTRAL-1'
+        }, {
+            checked: configItems.sesRegion === 'ca-central-1',
+            key: 'ca-central-1',
+            value: 'CA-CENTRAL-1'
+        }, {
+            checked: configItems.sesRegion === 'ap-south-1',
+            key: 'ap-south-1',
+            value: 'AP-SOUTH-1'
+        }, {
+            checked: configItems.sesRegion === 'ap-southeast-2',
+            key: 'ap-southeast-2',
+            value: 'AP-SOUTHEAST-2'
+        }, {
+            checked: configItems.sesRegion === 'sa-east-1',
+            key: 'sa-east-1',
+            value: 'SA-EAST-1'
+        }, {
+            checked: configItems.sesRegion === 'us-gov-west-1',
+            key: 'us-gov-west-1',
+            value: 'US-GOV-WEST-1'
         }];
 
         configItems.useSMTP = configItems.mailTransport === 'smtp' || !configItems.mailTransport;
@@ -165,7 +193,8 @@ router.post('/smtp-verify', upload.array(), passport.parseForm, passport.csrfPro
                 apiVersion: '2010-12-01',
                 accessKeyId: data.sesKey,
                 secretAccessKey: data.sesSecret,
-                region: data.sesRegion
+                region: data.sesRegion,
+                params: {ConfigurationSetName: data.sesDefaultSetName}
             })
         };
     } else {

--- a/views/settings.hbs
+++ b/views/settings.hbs
@@ -252,7 +252,7 @@
                     <div class="form-group">
                         <label for="ses-default-set-name" class="col-sm-2 control-label">{{#translate}}Default Set Name{{/translate}}</label>
                         <div class="col-sm-10">
-                            <input type="password" class="form-control" name="ses-default-set-name" id="ses-default-set-name" placeholder="{{#translate}}SES Default Set Name{{/translate}}" value="{{sesDefaultSetName}}">
+                            <input type="text" class="form-control" name="ses-default-set-name" id="ses-default-set-name" placeholder="{{#translate}}SES Default Set Name{{/translate}}" value="{{sesDefaultSetName}}">
                         </div>
                     </div>
 

--- a/views/settings.hbs
+++ b/views/settings.hbs
@@ -250,6 +250,13 @@
                     </div>
 
                     <div class="form-group">
+                        <label for="ses-default-set-name" class="col-sm-2 control-label">{{#translate}}Default Set Name{{/translate}}</label>
+                        <div class="col-sm-10">
+                            <input type="password" class="form-control" name="ses-default-set-name" id="ses-default-set-name" placeholder="{{#translate}}SES Default Set Name{{/translate}}" value="{{sesDefaultSetName}}">
+                        </div>
+                    </div>
+
+                    <div class="form-group">
                         <label for="ses-region" class="col-sm-2 control-label">{{#translate}}Region{{/translate}}</label>
                         <div class="col-sm-10">
                             <select class="form-control" id="ses-region" name="ses-region">


### PR DESCRIPTION
Adding all active regions for SES in settings 
Adding new settings for SES : Set Name.
Set Name is set by default for all mailing. No "per campaigns" settings.

Tested Ok on my private docker instance.