### PR TITLE
 Closes #846

### DIFF
--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -147,7 +147,7 @@
 
     <footer class="footer">
         <div class="container">
-            <p class="text-muted">&copy; 2016 Kreata OÜ <a href="https://mailtrain.org">Mailtrain.org</a>, <a href="mailto:info@mailtrain.org">info@mailtrain.org</a>. <a href="https://github.com/Mailtrain-org/mailtrain">{{#translate}}Source on GitHub{{/translate}}</a></p>
+            <p class="text-muted">&copy; 2016 - 2020< a href="https://mailtrain.org" alt="Mailtrain - Self Hosted Newsletter App" title="Mailtrain - Self Hosted Newsletter App">Mailtrain.org</a></p>
         </div>
     </footer>
 


### PR DESCRIPTION
Extended the copyright year (2016 - 2020), removed outdated company name and alternative contact metheds in favor of a SEO optimized link to the core project website