### PR TITLE
Fix plain text generation

### DIFF
--- a/server/lib/message-sender.js
+++ b/server/lib/message-sender.js
@@ -253,7 +253,7 @@ class MessageSender {
             html = tools.formatCampaignTemplate(html, this.tagLanguage, mergeTags, true, campaign, list, subscriptionGrouped);
         }
 
-        const generateText = !!(text || '').trim();
+        const generateText = !(text || '').trim();
         if (generateText) {
             text = htmlToText.fromString(html, {wordwrap: 130});
         } else {


### PR DESCRIPTION
Due to one inversion too many, the email’s plain text version was overridden with version generated from the html; while if there was no plain text, none would be generated.

This might also fix #882, if its author meant that *their* plain text does not get sent.
