### PR TITLE
(v2) feat. Make raw json data available for Handlebars templates

### DIFF
--- a/server/models/fields.js
+++ b/server/models/fields.js
@@ -97,6 +97,7 @@ fieldTypes.json = {
     cardinality: Cardinality.SINGLE,
     getHbsType: field => 'typeJson',
     forHbs: (field, value) => value,
+    jsonData: (field, value) => JSON.parse(value),
     parsePostValue: (field, value) => value,
     render: (field, value) => {
         try {
@@ -137,6 +138,7 @@ fieldTypes['checkbox-grouped'] = {
     enumerated: false,
     cardinality: Cardinality.MULTIPLE,
     getHbsType: field => 'typeCheckboxGrouped',
+    jsonData: (field, value) => (value || []).map(col => field.groupedOptions[col].name),
     render: (field, value) => {
         const subItems = (value || []).map(col => field.groupedOptions[col].name);
 
@@ -227,6 +229,7 @@ fieldTypes.option = {
         return !(['false', 'no', '0', ''].indexOf((value || '').toString().trim().toLowerCase()) >= 0)
     },
     getHbsType: field => 'typeOption',
+    jsonData: (field, value) => value ? true : false,
     forHbs: (field, value) => value ? 1 : 0,
     render: (field, value) => value ? field.settings.checkedLabel : field.settings.uncheckedLabel
 
@@ -737,6 +740,9 @@ function getMergeTags(fieldsGrouped, subscription, extraTags = {}) { // assumes 
         const fldCol = getFieldColumn(fld);
 
         mergeTags[fld.key] = type.render(fld, subscription[fldCol]);
+        if (type.jsonData) {
+            mergeTags[fld.key + "_RAW"] = type.jsonData(fld, subscription[fldCol]);
+        }
     }
 
     return mergeTags;


### PR DESCRIPTION
### Mailtrain v2
# Context
Handle is a quite powerful language and allows things like iterate on lists or contitionnal structures. 

However, it is not currently possible to do this in Mailtrain emails, because merge tags only contains parsed, string data that does not behave correctly in handlebars structures that expect json data, e.g. `{{#if <VARIABLE>}}`, `{{#unless <VARIABLE>}}`, `{{#each <VARIABLE>}}`.

This PR add, for relevents field types, a merge tag `MERGE_EXAMPLE_NAME_RAW` which contains the raw JSON Data. 

# Example

Assuming `MERGE_IS_MODERATOR` is an Option field, that does not belong to checkbox/dropdown/radio group (so it is rendered as a checkbox in the subscription page, and have a checked value and an unchecked value).

The following template will work as expected

```
Content of email, received by everyone


{{#if MERGE_IS_MODERATOR}}
Some specific information that only people marked as Moderators have to recived
{{/if}}
```

In the same way, it would expand the capabilities of radio buttons / checkboxes / JSON values field a lot, as would be possible to
have complex templates that uses data present in these fields to generate a dynamic email.

---
What do you think of this feature ?