### PR TITLE
Added new global permissions to manage main entities, hide menu entry and deny access if not have the permission (v2)

### DIFF
--- a/client/src/account/API.js
+++ b/client/src/account/API.js
@@ -10,6 +10,7 @@ import {Button} from '../lib/bootstrap-components';
 import {getUrl} from "../lib/urls";
 import {withComponentMixins} from "../lib/decorator-helpers";
 import styles from "./styles.scss"
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -35,6 +36,10 @@ export default class API extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageApi) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageApi');
+        }
         // noinspection JSIgnoredPromiseFromCall
         this.loadAccessToken();
     }

--- a/client/src/blacklist/List.js
+++ b/client/src/blacklist/List.js
@@ -10,6 +10,7 @@ import {Button} from "../lib/bootstrap-components";
 import {HTTPMethod} from "../lib/axios";
 import {tableAddRestActionButton, tableRestActionDialogInit, tableRestActionDialogRender} from "../lib/modals";
 import {withComponentMixins} from "../lib/decorator-helpers";
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -87,6 +88,10 @@ export default class List extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageBlacklist) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageBlacklist');
+        }
         this.clearFields();
     }
 

--- a/client/src/campaigns/CUD.js
+++ b/client/src/campaigns/CUD.js
@@ -37,7 +37,6 @@ import {getCampaignLabels, ListsSelectorHelper} from "./helpers";
 import {withComponentMixins} from "../lib/decorator-helpers";
 import interoperableErrors from "../../../shared/interoperable-errors";
 import {Trans} from "react-i18next";
-import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,

--- a/client/src/campaigns/CUD.js
+++ b/client/src/campaigns/CUD.js
@@ -37,6 +37,7 @@ import {getCampaignLabels, ListsSelectorHelper} from "./helpers";
 import {withComponentMixins} from "../lib/decorator-helpers";
 import interoperableErrors from "../../../shared/interoperable-errors";
 import {Trans} from "react-i18next";
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -254,6 +255,10 @@ export default class CUD extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageCampaigns) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageCampaigns');
+        }
         if (this.props.entity) {
             this.getFormValuesFromEntity(this.props.entity);
 

--- a/client/src/campaigns/List.js
+++ b/client/src/campaigns/List.js
@@ -13,6 +13,7 @@ import {tableAddDeleteButton, tableRestActionDialogInit, tableRestActionDialogRe
 import {withComponentMixins} from "../lib/decorator-helpers";
 import styles from "./styles.scss";
 import PropTypes from 'prop-types';
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -32,6 +33,13 @@ export default class List extends Component {
 
         this.state = {};
         tableRestActionDialogInit(this);
+    }
+
+    componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageCampaigns) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageCampaigns');
+        }
     }
 
     static propTypes = {

--- a/client/src/channels/CUD.js
+++ b/client/src/channels/CUD.js
@@ -37,6 +37,7 @@ import {getCampaignLabels, ListsSelectorHelper} from "../campaigns/helpers";
 import {withComponentMixins} from "../lib/decorator-helpers";
 import interoperableErrors from "../../../shared/interoperable-errors";
 import {Trans} from "react-i18next";
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -254,6 +255,10 @@ export default class CUD extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.user.admin && !mailtrainConfig.globalPermissions.manageChannels) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageChannels');
+        }
         if (this.props.entity) {
             this.getFormValuesFromEntity(this.props.entity);
 

--- a/client/src/channels/CUD.js
+++ b/client/src/channels/CUD.js
@@ -37,7 +37,6 @@ import {getCampaignLabels, ListsSelectorHelper} from "../campaigns/helpers";
 import {withComponentMixins} from "../lib/decorator-helpers";
 import interoperableErrors from "../../../shared/interoperable-errors";
 import {Trans} from "react-i18next";
-import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,

--- a/client/src/channels/CUD.js
+++ b/client/src/channels/CUD.js
@@ -255,7 +255,7 @@ export default class CUD extends Component {
 
     componentDidMount() {
         const t = this.props.t;
-        if (!mailtrainConfig.user.admin && !mailtrainConfig.globalPermissions.manageChannels) {
+        if (!mailtrainConfig.globalPermissions.manageChannels) {
             this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageChannels');
         }
         if (this.props.entity) {

--- a/client/src/channels/List.js
+++ b/client/src/channels/List.js
@@ -34,7 +34,7 @@ export default class List extends Component {
 
     componentDidMount() {
         const t = this.props.t;
-        if (!mailtrainConfig.user.admin && !mailtrainConfig.globalPermissions.manageChannels) {
+        if (!mailtrainConfig.globalPermissions.manageChannels) {
             this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageChannels');
         }
     }

--- a/client/src/channels/List.js
+++ b/client/src/channels/List.js
@@ -10,6 +10,7 @@ import {tableAddDeleteButton, tableRestActionDialogInit, tableRestActionDialogRe
 import {withComponentMixins} from "../lib/decorator-helpers";
 import styles from "./styles.scss";
 import PropTypes from 'prop-types';
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -29,6 +30,13 @@ export default class List extends Component {
 
     static propTypes = {
         permissions: PropTypes.object
+    }
+
+    componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.user.admin && !mailtrainConfig.globalPermissions.manageChannels) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageChannels');
+        }
     }
 
     render() {

--- a/client/src/lists/CUD.js
+++ b/client/src/lists/CUD.js
@@ -75,7 +75,7 @@ export default class CUD extends Component {
 
     componentDidMount() {
         const t = this.props.t;
-        if (!mailtrainConfig.user.admin && !mailtrainConfig.globalPermissions.manageLists) {
+        if (!mailtrainConfig.globalPermissions.manageLists) {
             this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
         }
         if (this.props.entity) {

--- a/client/src/lists/CUD.js
+++ b/client/src/lists/CUD.js
@@ -27,6 +27,7 @@ import {FieldWizard, UnsubscriptionMode} from '../../../shared/lists';
 import styles from "../lib/styles.scss";
 import {getMailerTypes} from "../send-configurations/helpers";
 import {withComponentMixins} from "../lib/decorator-helpers";
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -73,6 +74,10 @@ export default class CUD extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.user.admin && !mailtrainConfig.globalPermissions.manageLists) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
+        }
         if (this.props.entity) {
             this.getFormValuesFromEntity(this.props.entity);
 

--- a/client/src/lists/List.js
+++ b/client/src/lists/List.js
@@ -27,6 +27,13 @@ export default class List extends Component {
         tableRestActionDialogInit(this);
     }
 
+    componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.user.admin && !mailtrainConfig.globalPermissions.manageLists) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
+        }
+    }
+
     static propTypes = {
         permissions: PropTypes.object
     }
@@ -118,7 +125,6 @@ export default class List extends Component {
         ];
 
         return (
-            {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageList) ?
             <div>
                 {tableRestActionDialogRender(this)}
                 <Toolbar>
@@ -134,8 +140,7 @@ export default class List extends Component {
 
                 <Table ref={node => this.table = node} withHeader dataUrl="rest/lists-table" columns={columns} />
             </div>
-            :
-            <div><h1>No tienes permisos para manejar listas</h1></div>}
-        );
+        )
+
     }
 }

--- a/client/src/lists/List.js
+++ b/client/src/lists/List.js
@@ -10,6 +10,7 @@ import {tableAddDeleteButton, tableRestActionDialogInit, tableRestActionDialogRe
 import {withComponentMixins} from "../lib/decorator-helpers";
 import {withForm} from "../lib/form";
 import PropTypes from 'prop-types';
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -117,6 +118,7 @@ export default class List extends Component {
         ];
 
         return (
+            {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageList) ?
             <div>
                 {tableRestActionDialogRender(this)}
                 <Toolbar>
@@ -132,6 +134,8 @@ export default class List extends Component {
 
                 <Table ref={node => this.table = node} withHeader dataUrl="rest/lists-table" columns={columns} />
             </div>
+            :
+            <div><h1>No tienes permisos para manejar listas</h1></div>}
         );
     }
 }

--- a/client/src/lists/List.js
+++ b/client/src/lists/List.js
@@ -29,7 +29,7 @@ export default class List extends Component {
 
     componentDidMount() {
         const t = this.props.t;
-        if (!mailtrainConfig.user.admin && !mailtrainConfig.globalPermissions.manageLists) {
+        if (!mailtrainConfig.globalPermissions.manageLists) {
             this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
         }
     }

--- a/client/src/lists/fields/CUD.js
+++ b/client/src/lists/fields/CUD.js
@@ -32,6 +32,7 @@ import styles from "../../lib/styles.scss";
 import 'ace-builds/src-noconflict/mode-json';
 import 'ace-builds/src-noconflict/mode-handlebars';
 import {withComponentMixins} from "../../lib/decorator-helpers";
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -178,6 +179,10 @@ export default class CUD extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageLists) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
+        }
         if (this.props.entity) {
             this.getFormValuesFromEntity(this.props.entity);
 

--- a/client/src/lists/fields/List.js
+++ b/client/src/lists/fields/List.js
@@ -10,6 +10,7 @@ import {getFieldTypes} from './helpers';
 import {Icon} from "../../lib/bootstrap-components";
 import {tableAddDeleteButton, tableRestActionDialogInit, tableRestActionDialogRender} from "../../lib/modals";
 import {withComponentMixins} from "../../lib/decorator-helpers";
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -32,6 +33,10 @@ export default class List extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageLists) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
+        }
     }
 
     render() {

--- a/client/src/lists/imports/CUD.js
+++ b/client/src/lists/imports/CUD.js
@@ -30,6 +30,7 @@ import listStyles from "../styles.scss";
 import styles from "../../lib/styles.scss";
 import interoperableErrors from "../../../../shared/interoperable-errors";
 import {withComponentMixins} from "../../lib/decorator-helpers";
+import mailtrainConfig from 'mailtrainConfig';
 
 
 function truncate(str, len, ending = '...') {
@@ -209,6 +210,10 @@ export default class CUD extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageLists) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
+        }
         if (this.props.entity) {
             this.initFromEntity(this.props.entity);
         } else {

--- a/client/src/lists/imports/List.js
+++ b/client/src/lists/imports/List.js
@@ -13,6 +13,7 @@ import moment from "moment";
 import {inProgress} from '../../../../shared/imports';
 import {tableAddDeleteButton, tableRestActionDialogInit, tableRestActionDialogRender} from "../../lib/modals";
 import {withComponentMixins} from "../../lib/decorator-helpers";
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -37,6 +38,10 @@ export default class List extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageLists) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
+        }
     }
 
     render() {

--- a/client/src/lists/imports/List.js
+++ b/client/src/lists/imports/List.js
@@ -13,7 +13,6 @@ import moment from "moment";
 import {inProgress} from '../../../../shared/imports';
 import {tableAddDeleteButton, tableRestActionDialogInit, tableRestActionDialogRender} from "../../lib/modals";
 import {withComponentMixins} from "../../lib/decorator-helpers";
-import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,

--- a/client/src/lists/segments/CUD.js
+++ b/client/src/lists/segments/CUD.js
@@ -28,6 +28,7 @@ import {getRuleHelpers} from "./helpers";
 import RuleSettingsPane from "./RuleSettingsPane";
 import {withComponentMixins} from "../../lib/decorator-helpers";
 import clone from "clone";
+import mailtrainConfig from 'mailtrainConfig';
 
 // https://stackoverflow.com/a/4819886/1601953
 const isTouchDevice = !!('ontouchstart' in window || navigator.maxTouchPoints);
@@ -123,6 +124,10 @@ export default class CUD extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageLists) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
+        }
         if (this.props.entity) {
             this.getFormValuesFromEntity(this.props.entity);
 

--- a/client/src/lists/segments/List.js
+++ b/client/src/lists/segments/List.js
@@ -9,6 +9,7 @@ import {Table} from '../../lib/table';
 import {Icon} from "../../lib/bootstrap-components";
 import {tableAddDeleteButton, tableRestActionDialogInit, tableRestActionDialogRender} from "../../lib/modals";
 import {withComponentMixins} from "../../lib/decorator-helpers";
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -29,6 +30,10 @@ export default class List extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageLists) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
+        }
     }
 
     render() {

--- a/client/src/lists/subscriptions/CUD.js
+++ b/client/src/lists/subscriptions/CUD.js
@@ -91,7 +91,7 @@ export default class CUD extends Component {
 
     componentDidMount() {
         const t = this.props.t;
-        if (!mailtrainConfig.user.admin && !mailtrainConfig.globalPermissions.manageLists) {
+        if (!mailtrainConfig.globalPermissions.manageLists) {
             this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
         }
 

--- a/client/src/lists/subscriptions/CUD.js
+++ b/client/src/lists/subscriptions/CUD.js
@@ -25,6 +25,7 @@ import {getFieldColumn, SubscriptionStatus} from '../../../../shared/lists';
 import {getFieldTypes, getSubscriptionStatusLabels} from './helpers';
 import moment from 'moment-timezone';
 import {withComponentMixins} from "../../lib/decorator-helpers";
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -89,6 +90,11 @@ export default class CUD extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.user.admin && !mailtrainConfig.globalPermissions.manageLists) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
+        }
+
         if (this.props.entity) {
             this.getFormValuesFromEntity(this.props.entity);
 

--- a/client/src/lists/subscriptions/List.js
+++ b/client/src/lists/subscriptions/List.js
@@ -21,6 +21,7 @@ import {
 } from "../../lib/modals";
 import listStyles from "../styles.scss";
 import {withComponentMixins} from "../../lib/decorator-helpers";
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -58,6 +59,10 @@ export default class List extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.user.admin && !mailtrainConfig.globalPermissions.manageLists) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
+        }
         this.populateFormValues({
             segment: this.props.segmentId || ''
         });

--- a/client/src/lists/subscriptions/List.js
+++ b/client/src/lists/subscriptions/List.js
@@ -60,7 +60,7 @@ export default class List extends Component {
 
     componentDidMount() {
         const t = this.props.t;
-        if (!mailtrainConfig.user.admin && !mailtrainConfig.globalPermissions.manageLists) {
+        if (!mailtrainConfig.globalPermissions.manageLists) {
             this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageLists');
         }
         this.populateFormValues({

--- a/client/src/namespaces/CUD.js
+++ b/client/src/namespaces/CUD.js
@@ -93,6 +93,10 @@ export default class CUD extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageNamespaces) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageNamespaces');
+        }
         if (this.props.entity) {
             this.getFormValuesFromEntity(this.props.entity);
         } else {

--- a/client/src/namespaces/List.js
+++ b/client/src/namespaces/List.js
@@ -29,7 +29,12 @@ export default class List extends Component {
     static propTypes = {
         permissions: PropTypes.object
     }
-
+    componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageNamespaces) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageNamespaces');
+        }
+    }
     render() {
         const t = this.props.t;
 

--- a/client/src/root.js
+++ b/client/src/root.js
@@ -73,7 +73,7 @@ class Root extends Component {
 		                const entry = topLevelItems[entryKey.toLowerCase()];
 		                const link = entry.link || entry.externalLink;
 
-		                if (mailtrainConfig.user.admin || mailtrainConfig.globalPermissions["manage"+entryKey]) {
+		                if (mailtrainConfig.user.admin || mailtrainConfig.globalPermissions["displayManage"+entryKey]) {
 		                    if (link && path.startsWith(link)) {
 		                        topLevelMenu.push(<NavLink key={entryKey.toLowerCase()} className="active" to={link}>{entry.title} <span className="sr-only">{t('current')}</span></NavLink>);
 		                    } else {
@@ -87,17 +87,17 @@ class Root extends Component {
                             <ul className="navbar-nav mt-navbar-nav-left">
                                 {topLevelMenu}
                                 <NavDropdown label={t('administration')}>
-                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageUsers) &&
+                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.displayManageUsers) &&
                                         <DropdownLink to="/users">{t('users')}</DropdownLink>}
-                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageNamespaces) &&
+                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.displayManageNamespaces) &&
                                         <DropdownLink to="/namespaces">{t('namespaces')}</DropdownLink>}
                                     {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageSettings) &&
                                         <DropdownLink to="/settings">{t('globalSettings')}</DropdownLink>}
-                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageSendConfigurations) &&
+                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.displayManageSendConfigurations) &&
                                         <DropdownLink to="/send-configurations">{t('sendConfigurations')}</DropdownLink>}
                                     {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageBlacklist) &&
                                         <DropdownLink to="/blacklist">{t('blacklist')}</DropdownLink>}
-                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageApi) &&
+                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.displayManageApi) &&
                                         <DropdownLink to="/account/api">{t('api')}</DropdownLink>}
                                 </NavDropdown>
                             </ul>

--- a/client/src/root.js
+++ b/client/src/root.js
@@ -70,13 +70,12 @@ class Root extends Component {
                 if (mailtrainConfig.isAuthenticated) {
 
                     const gP = mailtrainConfig.globalPermissions;
-                    const superadmin = mailtrainConfig.user.admin;
 
 		            for (const entryKey of topLevelMenuKeys) {
 		                const entry = topLevelItems[entryKey.toLowerCase()];
 		                const link = entry.link || entry.externalLink;
 
-		                if (superadmin || gP["manage"+entryKey]) {
+		                if (gP["manage"+entryKey]) {
 		                    if (link && path.startsWith(link)) {
 		                        topLevelMenu.push(<NavLink key={entryKey.toLowerCase()} className="active" to={link}>{entry.title} <span className="sr-only">{t('current')}</span></NavLink>);
 		                    } else {
@@ -89,20 +88,20 @@ class Root extends Component {
                         <>
                             <ul className="navbar-nav mt-navbar-nav-left">
                                 {topLevelMenu}
-                                {(superadmin || gP.manageUsers || gP.manageNamespaces || gP.manageSettings || 
+                                {(gP.manageUsers || gP.manageNamespaces || gP.manageSettings || 
                                   gP.manageSendConfigurations || gP.manageBlacklist || gP.manageApi) &&
                                   <NavDropdown label={t('administration')}>
-                                    {(superadmin || gP.manageUsers) &&
+                                    {(gP.manageUsers) &&
                                         <DropdownLink to="/users">{t('users')}</DropdownLink>}
-                                    {(superadmin || gP.manageNamespaces) &&
+                                    {(gP.manageNamespaces) &&
                                         <DropdownLink to="/namespaces">{t('namespaces')}</DropdownLink>}
-                                    {(superadmin || gP.manageSettings) &&
+                                    {(gP.manageSettings) &&
                                         <DropdownLink to="/settings">{t('globalSettings')}</DropdownLink>}
-                                    {(superadmin || gP.manageSendConfigurations) &&
+                                    {(gP.manageSendConfigurations) &&
                                         <DropdownLink to="/send-configurations">{t('sendConfigurations')}</DropdownLink>}
-                                    {(superadmin || gP.manageBlacklist) &&
+                                    {(gP.manageBlacklist) &&
                                         <DropdownLink to="/blacklist">{t('blacklist')}</DropdownLink>}
-                                    {(superadmin || gP.manageApi) &&
+                                    {(gP.manageApi) &&
                                         <DropdownLink to="/account/api">{t('api')}</DropdownLink>}
                                   </NavDropdown>}
                             </ul>

--- a/client/src/root.js
+++ b/client/src/root.js
@@ -76,7 +76,7 @@ class Root extends Component {
 		                const entry = topLevelItems[entryKey.toLowerCase()];
 		                const link = entry.link || entry.externalLink;
 
-		                if (superadmin || gP["displayManage"+entryKey]) {
+		                if (superadmin || gP["manage"+entryKey]) {
 		                    if (link && path.startsWith(link)) {
 		                        topLevelMenu.push(<NavLink key={entryKey.toLowerCase()} className="active" to={link}>{entry.title} <span className="sr-only">{t('current')}</span></NavLink>);
 		                    } else {
@@ -89,20 +89,20 @@ class Root extends Component {
                         <>
                             <ul className="navbar-nav mt-navbar-nav-left">
                                 {topLevelMenu}
-                                {(superadmin || gP.displayManageUsers || gP.displayManageNamespaces || gP.manageSettings || 
-                                  gP.displayManageSendConfigurations || gP.manageBlacklist || gP.displayManageApi) &&
+                                {(superadmin || gP.manageUsers || gP.manageNamespaces || gP.manageSettings || 
+                                  gP.manageSendConfigurations || gP.manageBlacklist || gP.manageApi) &&
                                   <NavDropdown label={t('administration')}>
-                                    {(superadmin || gP.displayManageUsers) &&
+                                    {(superadmin || gP.manageUsers) &&
                                         <DropdownLink to="/users">{t('users')}</DropdownLink>}
-                                    {(superadmin || gP.displayManageNamespaces) &&
+                                    {(superadmin || gP.manageNamespaces) &&
                                         <DropdownLink to="/namespaces">{t('namespaces')}</DropdownLink>}
                                     {(superadmin || gP.manageSettings) &&
                                         <DropdownLink to="/settings">{t('globalSettings')}</DropdownLink>}
-                                    {(superadmin || gP.displayManageSendConfigurations) &&
+                                    {(superadmin || gP.manageSendConfigurations) &&
                                         <DropdownLink to="/send-configurations">{t('sendConfigurations')}</DropdownLink>}
                                     {(superadmin || gP.manageBlacklist) &&
                                         <DropdownLink to="/blacklist">{t('blacklist')}</DropdownLink>}
-                                    {(superadmin || gP.displayManageApi) &&
+                                    {(superadmin || gP.manageApi) &&
                                         <DropdownLink to="/account/api">{t('api')}</DropdownLink>}
                                   </NavDropdown>}
                             </ul>

--- a/client/src/root.js
+++ b/client/src/root.js
@@ -69,11 +69,14 @@ class Root extends Component {
 
                 if (mailtrainConfig.isAuthenticated) {
 
+                    const gP = mailtrainConfig.globalPermissions;
+                    const superadmin = mailtrainConfig.user.admin;
+
 		            for (const entryKey of topLevelMenuKeys) {
 		                const entry = topLevelItems[entryKey.toLowerCase()];
 		                const link = entry.link || entry.externalLink;
 
-		                if (mailtrainConfig.user.admin || mailtrainConfig.globalPermissions["displayManage"+entryKey]) {
+		                if (superadmin || gP["displayManage"+entryKey]) {
 		                    if (link && path.startsWith(link)) {
 		                        topLevelMenu.push(<NavLink key={entryKey.toLowerCase()} className="active" to={link}>{entry.title} <span className="sr-only">{t('current')}</span></NavLink>);
 		                    } else {
@@ -86,20 +89,22 @@ class Root extends Component {
                         <>
                             <ul className="navbar-nav mt-navbar-nav-left">
                                 {topLevelMenu}
-                                <NavDropdown label={t('administration')}>
-                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.displayManageUsers) &&
+                                {(superadmin || gP.displayManageUsers || gP.displayManageNamespaces || gP.manageSettings || 
+                                  gP.displayManageSendConfigurations || gP.manageBlacklist || gP.displayManageApi) &&
+                                  <NavDropdown label={t('administration')}>
+                                    {(superadmin || gP.displayManageUsers) &&
                                         <DropdownLink to="/users">{t('users')}</DropdownLink>}
-                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.displayManageNamespaces) &&
+                                    {(superadmin || gP.displayManageNamespaces) &&
                                         <DropdownLink to="/namespaces">{t('namespaces')}</DropdownLink>}
-                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageSettings) &&
+                                    {(superadmin || gP.manageSettings) &&
                                         <DropdownLink to="/settings">{t('globalSettings')}</DropdownLink>}
-                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.displayManageSendConfigurations) &&
+                                    {(superadmin || gP.displayManageSendConfigurations) &&
                                         <DropdownLink to="/send-configurations">{t('sendConfigurations')}</DropdownLink>}
-                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageBlacklist) &&
+                                    {(superadmin || gP.manageBlacklist) &&
                                         <DropdownLink to="/blacklist">{t('blacklist')}</DropdownLink>}
-                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.displayManageApi) &&
+                                    {(superadmin || gP.displayManageApi) &&
                                         <DropdownLink to="/account/api">{t('api')}</DropdownLink>}
-                                </NavDropdown>
+                                  </NavDropdown>}
                             </ul>
                             <ul className="navbar-nav mt-navbar-nav-right">
                                 {getLanguageChooser(t)}

--- a/client/src/root.js
+++ b/client/src/root.js
@@ -28,10 +28,10 @@ import {getUrl} from "./lib/urls";
 import {withComponentMixins} from "./lib/decorator-helpers";
 import Update from "./settings/Update";
 
-const topLevelMenuKeys = ['lists', 'channels', 'templates', 'campaigns'];
+const topLevelMenuKeys = ['Lists', 'Channels', 'Templates', 'Campaigns'];
 
 if (mailtrainConfig.reportsEnabled) {
-    topLevelMenuKeys.push('reports');
+    topLevelMenuKeys.push('Reports');
 }
 
 
@@ -67,29 +67,38 @@ class Root extends Component {
 
                 const topLevelMenu = [];
 
-                for (const entryKey of topLevelMenuKeys) {
-                    const entry = topLevelItems[entryKey];
-                    const link = entry.link || entry.externalLink;
-
-                    if (link && path.startsWith(link)) {
-                        topLevelMenu.push(<NavLink key={entryKey} className="active" to={link}>{entry.title} <span className="sr-only">{t('current')}</span></NavLink>);
-                    } else {
-                        topLevelMenu.push(<NavLink key={entryKey} to={link}>{entry.title}</NavLink>);
-                    }
-                }
-
                 if (mailtrainConfig.isAuthenticated) {
+
+		            for (const entryKey of topLevelMenuKeys) {
+		                const entry = topLevelItems[entryKey.toLowerCase()];
+		                const link = entry.link || entry.externalLink;
+
+		                if (mailtrainConfig.user.admin || mailtrainConfig.globalPermissions["manage"+entryKey]) {
+		                    if (link && path.startsWith(link)) {
+		                        topLevelMenu.push(<NavLink key={entryKey.toLowerCase()} className="active" to={link}>{entry.title} <span className="sr-only">{t('current')}</span></NavLink>);
+		                    } else {
+		                        topLevelMenu.push(<NavLink key={entryKey.toLowerCase()} to={link}>{entry.title}</NavLink>);
+		                    }
+		                }
+		            }
+
                     return (
                         <>
                             <ul className="navbar-nav mt-navbar-nav-left">
                                 {topLevelMenu}
                                 <NavDropdown label={t('administration')}>
-                                    {mailtrainConfig.globalPermissions.displayManageUsers && <DropdownLink to="/users">{t('users')}</DropdownLink>}
-                                    <DropdownLink to="/namespaces">{t('namespaces')}</DropdownLink>
-                                    {mailtrainConfig.globalPermissions.manageSettings && <DropdownLink to="/settings">{t('globalSettings')}</DropdownLink>}
-                                    <DropdownLink to="/send-configurations">{t('sendConfigurations')}</DropdownLink>
-                                    {mailtrainConfig.globalPermissions.manageBlacklist && <DropdownLink to="/blacklist">{t('blacklist')}</DropdownLink>}
-                                    <DropdownLink to="/account/api">{t('api')}</DropdownLink>
+                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageUsers) &&
+                                        <DropdownLink to="/users">{t('users')}</DropdownLink>}
+                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageNamespaces) &&
+                                        <DropdownLink to="/namespaces">{t('namespaces')}</DropdownLink>}
+                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageSettings) &&
+                                        <DropdownLink to="/settings">{t('globalSettings')}</DropdownLink>}
+                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageSendConfigurations) &&
+                                        <DropdownLink to="/send-configurations">{t('sendConfigurations')}</DropdownLink>}
+                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageBlacklist) &&
+                                        <DropdownLink to="/blacklist">{t('blacklist')}</DropdownLink>}
+                                    {(mailtrainConfig.user.admin || mailtrainConfig.globalPermissions.manageApi) &&
+                                        <DropdownLink to="/account/api">{t('api')}</DropdownLink>}
                                 </NavDropdown>
                             </ul>
                             <ul className="navbar-nav mt-navbar-nav-right">
@@ -101,6 +110,7 @@ class Root extends Component {
                             </ul>
                         </>
                     );
+
                 } else {
                     return (
                         <>

--- a/client/src/send-configurations/CUD.js
+++ b/client/src/send-configurations/CUD.js
@@ -91,6 +91,10 @@ export default class CUD extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageSendConfigurations) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageSendConfigurations');
+        }
         if (this.props.entity) {
             this.getFormValuesFromEntity(this.props.entity);
         } else {

--- a/client/src/send-configurations/List.js
+++ b/client/src/send-configurations/List.js
@@ -11,6 +11,7 @@ import {getMailerTypes} from './helpers';
 import {tableAddDeleteButton, tableRestActionDialogInit, tableRestActionDialogRender} from "../lib/modals";
 import {withComponentMixins} from "../lib/decorator-helpers";
 import PropTypes from 'prop-types';
+import mailtrainConfig from 'mailtrainConfig';
 
 
 @withComponentMixins([
@@ -31,6 +32,13 @@ export default class List extends Component {
 
     static propTypes = {
         permissions: PropTypes.object
+    }
+
+    componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageSendConfigurations) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageSendConfigurations');
+        }
     }
 
     render() {

--- a/client/src/settings/Update.js
+++ b/client/src/settings/Update.js
@@ -19,6 +19,7 @@ import {
 } from '../lib/form';
 import {withErrorHandling} from '../lib/error-handling';
 import {withComponentMixins} from "../lib/decorator-helpers";
+import mailtrainConfig from 'mailtrainConfig';
 
 @withComponentMixins([
     withTranslation,
@@ -45,6 +46,10 @@ export default class Update extends Component {
     }
 
     componentDidMount() {
+        const t = this.props.t;
+        if (!mailtrainConfig.globalPermissions.manageSettings) {
+            this.navigateToWithFlashMessage('/', 'danger', t('permissionDenied')+': manageSettings');
+        }
         this.getFormValuesFromEntity(this.props.entity);
     }
 

--- a/locales/de-DE/common.json
+++ b/locales/de-DE/common.json
@@ -1064,5 +1064,6 @@
   "channelName": "Channel \"{{name}}\"",
   "cloneCampaign": "Clone Campaign",
   "next": "Next",
-  "selectCampaignToBeCloned": "Select campaign to be cloned."
+  "selectCampaignToBeCloned": "Select campaign to be cloned.",
+  "permissionDenied": "Zugang verweigert"
 }

--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -1070,5 +1070,6 @@
   "channelName": "Channel \"{{name}}\"",
   "cloneCampaign": "Clone Campaign",
   "next": "Next",
-  "selectCampaignToBeCloned": "Select campaign to be cloned."
+  "selectCampaignToBeCloned": "Select campaign to be cloned.",
+  "permissionDenied": "Permission Denied"
 }

--- a/locales/es-ES/common.json
+++ b/locales/es-ES/common.json
@@ -1094,5 +1094,6 @@
   "selectCampaignToBeCloned": "Elige la campaña que será clonada.",
   "tagLanguage": "Lenguaje de marcado",
   "tagLanguageMustBeSelected": "Debes seleccionar un lenguaje de marcado",
-  "helpText": "Texto de ayuda"
+  "helpText": "Texto de ayuda",
+  "permissionDenied": "Permission Denied"
 }

--- a/locales/es-ES/common.json
+++ b/locales/es-ES/common.json
@@ -1095,5 +1095,5 @@
   "tagLanguage": "Lenguaje de marcado",
   "tagLanguageMustBeSelected": "Debes seleccionar un lenguaje de marcado",
   "helpText": "Texto de ayuda",
-  "permissionDenied": "Permission Denied"
+  "permissionDenied": "Permiso denegado"
 }

--- a/locales/fr-FR/common.json
+++ b/locales/fr-FR/common.json
@@ -1065,5 +1065,6 @@
   "channelName": "Channel \"{{name}}\"",
   "cloneCampaign": "Clone Campaign",
   "next": "Next",
-  "selectCampaignToBeCloned": "Select campaign to be cloned."
+  "selectCampaignToBeCloned": "Select campaign to be cloned.",
+  "permissionDenied": "Permission refusée"
 }

--- a/locales/pt-BR/common.json
+++ b/locales/pt-BR/common.json
@@ -1143,5 +1143,6 @@
   "channelName": "Channel \"{{name}}\"",
   "cloneCampaign": "Clone Campaign",
   "next": "Next",
-  "selectCampaignToBeCloned": "Select campaign to be cloned."
+  "selectCampaignToBeCloned": "Select campaign to be cloned.",
+  "permissionDenied": "Permissão negada"
 }

--- a/server/config/default.yaml
+++ b/server/config/default.yaml
@@ -277,12 +277,12 @@ defaultRoles:
       name: Global Master
       admin: true
       description: All permissions
-      permissions: [rebuildPermissions, createJavascriptWithROAccess, manageBlacklist, manageSettings, setupAutomation]
+      permissions: [rebuildPermissions, createJavascriptWithROAccess, manageBlacklist, manageSettings,  manageUsers, manageLists, manageChannels, manageTemplates, manageCampaigns, manageReports, manageApi, manageSendConfigurations, manageNamespaces, setupAutomation]
       rootNamespaceRole: master
     campaignsAdmin:
       name: Campaigns Admin
       description: Under the namespace in which the user is located, the user has all permissions for managing lists, templates and campaigns and the permission to send to send configurations.
-      permissions: [setupAutomation, displayManageLists, displayManageChannels, displayManageTemplates, displayManageCampaigns, displayManageReports, displayManageApi, displayManageSendConfigurations, displayManageNamespaces]
+      permissions: [setupAutomation, manageLists, manageChannels, manageTemplates, manageCampaigns, manageReports, manageApi, manageSendConfigurations, manageNamespaces]
       ownNamespaceRole: campaignsAdmin
     campaignsAdminWithoutNamespace:
       name: Campaigns Admin (multiple namespaces)

--- a/server/config/default.yaml
+++ b/server/config/default.yaml
@@ -277,12 +277,12 @@ defaultRoles:
       name: Global Master
       admin: true
       description: All permissions
-      permissions: [rebuildPermissions, createJavascriptWithROAccess, displayManageUsers, manageBlacklist, manageSettings, setupAutomation]
+      permissions: [rebuildPermissions, createJavascriptWithROAccess, manageUsers, manageBlacklist, manageSettings, setupAutomation]
       rootNamespaceRole: master
     campaignsAdmin:
       name: Campaigns Admin
       description: Under the namespace in which the user is located, the user has all permissions for managing lists, templates and campaigns and the permission to send to send configurations.
-      permissions: [setupAutomation]
+      permissions: [setupAutomation, manageLists, manageChannels, manageTemplates, manageCampaigns, manageReports, manageApi, manageSendConfigurations, manageNamespaces]
       ownNamespaceRole: campaignsAdmin
     campaignsAdminWithoutNamespace:
       name: Campaigns Admin (multiple namespaces)

--- a/server/config/default.yaml
+++ b/server/config/default.yaml
@@ -277,12 +277,12 @@ defaultRoles:
       name: Global Master
       admin: true
       description: All permissions
-      permissions: [rebuildPermissions, createJavascriptWithROAccess, manageUsers, manageBlacklist, manageSettings, setupAutomation]
+      permissions: [rebuildPermissions, createJavascriptWithROAccess, manageBlacklist, manageSettings, setupAutomation]
       rootNamespaceRole: master
     campaignsAdmin:
       name: Campaigns Admin
       description: Under the namespace in which the user is located, the user has all permissions for managing lists, templates and campaigns and the permission to send to send configurations.
-      permissions: [setupAutomation, manageLists, manageChannels, manageTemplates, manageCampaigns, manageReports, manageApi, manageSendConfigurations, manageNamespaces]
+      permissions: [setupAutomation, displayManageLists, displayManageChannels, displayManageTemplates, displayManageCampaigns, displayManageReports, displayManageApi, displayManageSendConfigurations, displayManageNamespaces]
       ownNamespaceRole: campaignsAdmin
     campaignsAdminWithoutNamespace:
       name: Campaigns Admin (multiple namespaces)

--- a/server/lib/client-helpers.js
+++ b/server/lib/client-helpers.js
@@ -40,8 +40,7 @@ async function getAuthenticatedConfig(context) {
         user: {
             id: context.user.id,
             username: context.user.username,
-            namespace: context.user.namespace,
-            admin: (config.roles.global[context.user.role]["admin"] || false)
+            namespace: context.user.namespace
         },
         globalPermissions,
         editors: config.editors,

--- a/server/lib/client-helpers.js
+++ b/server/lib/client-helpers.js
@@ -40,7 +40,8 @@ async function getAuthenticatedConfig(context) {
         user: {
             id: context.user.id,
             username: context.user.username,
-            namespace: context.user.namespace
+            namespace: context.user.namespace,
+            admin: (config.roles.global[context.user.role]["admin"] || false)
         },
         globalPermissions,
         editors: config.editors,

--- a/server/lib/translate.js
+++ b/server/lib/translate.js
@@ -15,6 +15,8 @@ function loadLanguage(longCode) {
 loadLanguage('en-US');
 loadLanguage('es-ES');
 loadLanguage('pt-BR');
+loadLanguage('de-DE');
+loadLanguage('fr-FR');
 resourcesCommon['fk-FK'] = convertToFake(resourcesCommon['en-US']);
 
 const resources = {};

--- a/server/models/campaigns.js
+++ b/server/models/campaigns.js
@@ -68,7 +68,6 @@ function hash(entity, content) {
 }
 
 async function _listDTAjax(context, namespaceId, channelId, params) {
-    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'campaign', requiredOperations: ['view'] }],
@@ -103,7 +102,6 @@ async function listByChannelDTAjax(context, channelId, params) {
 }
 
 async function listChildrenDTAjax(context, campaignId, params) {
-    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'campaign', requiredOperations: ['view'] }],
@@ -117,7 +115,6 @@ async function listChildrenDTAjax(context, campaignId, params) {
 
 
 async function listWithContentDTAjax(context, params) {
-    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'campaign', requiredOperations: ['view'] }],
@@ -130,7 +127,6 @@ async function listWithContentDTAjax(context, params) {
 }
 
 async function listOthersWhoseListsAreIncludedDTAjax(context, campaignId, listIds, params) {
-    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'campaign', requiredOperations: ['view'] }],
@@ -144,7 +140,6 @@ async function listOthersWhoseListsAreIncludedDTAjax(context, campaignId, listId
 }
 
 async function listTestUsersDTAjax(context, campaignId, params) {
-    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'campaign', campaignId, 'view');
 

--- a/server/models/campaigns.js
+++ b/server/models/campaigns.js
@@ -68,6 +68,7 @@ function hash(entity, content) {
 }
 
 async function _listDTAjax(context, namespaceId, channelId, params) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'campaign', requiredOperations: ['view'] }],
@@ -102,6 +103,7 @@ async function listByChannelDTAjax(context, channelId, params) {
 }
 
 async function listChildrenDTAjax(context, campaignId, params) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'campaign', requiredOperations: ['view'] }],
@@ -115,6 +117,7 @@ async function listChildrenDTAjax(context, campaignId, params) {
 
 
 async function listWithContentDTAjax(context, params) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'campaign', requiredOperations: ['view'] }],
@@ -127,6 +130,7 @@ async function listWithContentDTAjax(context, params) {
 }
 
 async function listOthersWhoseListsAreIncludedDTAjax(context, campaignId, listIds, params) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'campaign', requiredOperations: ['view'] }],
@@ -140,6 +144,7 @@ async function listOthersWhoseListsAreIncludedDTAjax(context, campaignId, listId
 }
 
 async function listTestUsersDTAjax(context, campaignId, params) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'campaign', campaignId, 'view');
 
@@ -225,6 +230,7 @@ async function listTestUsersDTAjax(context, campaignId, params) {
 }
 
 async function _listSubscriberResultsDTAjax(context, campaignId, getSubsQrys, columns, params) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'campaign', campaignId, 'view');
 
@@ -319,6 +325,7 @@ async function listOpensDTAjax(context, campaignId, params) {
 }
 
 async function listLinkClicksDTAjax(context, campaignId, params) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await knex.transaction(async (tx) => {
         await shares.enforceEntityPermissionTx(tx, context, 'campaign', campaignId, 'viewStats');
 
@@ -353,6 +360,7 @@ async function lockByIdTx(tx, id) {
 }
 
 async function rawGetByTx(tx, key, id) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     const entity = await tx('campaigns').where('campaigns.' + key, id)
         .leftJoin('campaign_lists', 'campaigns.id', 'campaign_lists.campaign')
         .groupBy('campaigns.id')
@@ -386,6 +394,7 @@ async function rawGetByTx(tx, key, id) {
 }
 
 async function getByIdTx(tx, context, id, withPermissions = true, content = Content.ALL) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     await shares.enforceEntityPermissionTx(tx, context, 'campaign', id, 'view');
 
     let entity = await rawGetByTx(tx, 'id', id);
@@ -445,6 +454,7 @@ async function getByCid(context, cid) {
 }
 
 async function _validateAndPreprocess(tx, context, entity, isCreate, content) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     if (content === Content.ALL || content === Content.WITHOUT_SOURCE_CUSTOM || content === Content.RSS_ENTRY) {
         await namespaceHelpers.validateEntity(tx, entity);
 
@@ -481,6 +491,7 @@ async function _validateAndPreprocess(tx, context, entity, isCreate, content) {
 }
 
 async function _createTx(tx, context, entity, content) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'namespace', entity.namespace, 'createCampaign');
 
@@ -579,6 +590,7 @@ async function createRssTx(tx, context, entity) {
 }
 
 async function _validateChannelMoveTx(tx, context, entity, existing) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     if (existing.channel !== entity.channel) {
         await shares.enforceEntityPermission(context, 'channel', entity.channel, 'createCampaign');
         await shares.enforceEntityPermission(context, 'campaign', entity.id, 'delete');
@@ -637,6 +649,7 @@ async function updateWithConsistencyCheck(context, entity, content) {
 }
 
 async function _removeTx(tx, context, id, existing = null, overrideTypeCheck = false) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     await shares.enforceEntityPermissionTx(tx, context, 'campaign', id, 'delete');
 
     if (!existing) {
@@ -861,6 +874,7 @@ async function prepareCampaignMessages(campaignId) {
 }
 
 async function _changeStatus(context, campaignId, permittedCurrentStates, newState, invalidStateMessage, extraData) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     await knex.transaction(async tx => {
         // This is quite inefficient because it selects the same row 3 times. However as status is changed
         // rather infrequently, we keep it this way for simplicity
@@ -925,6 +939,7 @@ async function stop(context, campaignId) {
 }
 
 async function reset(context, campaignId) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     await knex.transaction(async tx => {
         // This is quite inefficient because it selects the same row 3 times. However as RESET is
         // going to be called rather infrequently, we keep it this way for simplicity
@@ -965,6 +980,7 @@ async function disable(context, campaignId) {
 
 
 async function getStatisticsOpened(context, id) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'campaign', id, 'viewStats');
 
@@ -979,6 +995,7 @@ async function getStatisticsOpened(context, id) {
 }
 
 async function fetchRssCampaign(context, cid) {
+    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await knex.transaction(async tx => {
 
         const campaign = await tx('campaigns').where('cid', cid).select(['id', 'type']).first();

--- a/server/models/campaigns.js
+++ b/server/models/campaigns.js
@@ -230,7 +230,6 @@ async function listTestUsersDTAjax(context, campaignId, params) {
 }
 
 async function _listSubscriberResultsDTAjax(context, campaignId, getSubsQrys, columns, params) {
-    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'campaign', campaignId, 'view');
 
@@ -325,7 +324,6 @@ async function listOpensDTAjax(context, campaignId, params) {
 }
 
 async function listLinkClicksDTAjax(context, campaignId, params) {
-    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await knex.transaction(async (tx) => {
         await shares.enforceEntityPermissionTx(tx, context, 'campaign', campaignId, 'viewStats');
 
@@ -978,7 +976,6 @@ async function disable(context, campaignId) {
 
 
 async function getStatisticsOpened(context, id) {
-    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'campaign', id, 'viewStats');
 
@@ -993,7 +990,6 @@ async function getStatisticsOpened(context, id) {
 }
 
 async function fetchRssCampaign(context, cid) {
-    shares.enforceGlobalPermission(context, 'manageCampaigns');
     return await knex.transaction(async tx => {
 
         const campaign = await tx('campaigns').where('cid', cid).select(['id', 'type']).first();

--- a/server/models/campaigns.js
+++ b/server/models/campaigns.js
@@ -360,7 +360,6 @@ async function lockByIdTx(tx, id) {
 }
 
 async function rawGetByTx(tx, key, id) {
-    shares.enforceGlobalPermission(context, 'manageCampaigns');
     const entity = await tx('campaigns').where('campaigns.' + key, id)
         .leftJoin('campaign_lists', 'campaigns.id', 'campaign_lists.campaign')
         .groupBy('campaigns.id')
@@ -394,7 +393,6 @@ async function rawGetByTx(tx, key, id) {
 }
 
 async function getByIdTx(tx, context, id, withPermissions = true, content = Content.ALL) {
-    shares.enforceGlobalPermission(context, 'manageCampaigns');
     await shares.enforceEntityPermissionTx(tx, context, 'campaign', id, 'view');
 
     let entity = await rawGetByTx(tx, 'id', id);

--- a/server/models/channels.js
+++ b/server/models/channels.js
@@ -30,7 +30,6 @@ function hash(entity) {
 }
 
 async function listDTAjax(context, params) {
-    shares.enforceGlobalPermission(context, 'manageChannels');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'channel', requiredOperations: ['view'] }],
@@ -96,7 +95,6 @@ async function _getByTx(tx, context, key, id, withPermissions = true) {
 }
 
 async function getByIdTx(tx, context, id, withPermissions = true) {
-    shares.enforceGlobalPermission(context, 'manageChannels');
     await shares.enforceEntityPermissionTx(tx, context, 'channel', id, 'view');
 
     return await _getByTx(tx, context, 'id', id, withPermissions);

--- a/server/models/channels.js
+++ b/server/models/channels.js
@@ -45,7 +45,6 @@ async function listDTAjax(context, params) {
 }
 
 async function listWithCreateCampaignPermissionDTAjax(context, params) {
-    shares.enforceGlobalPermission(context, 'manageChannels');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'channel', requiredOperations: ['createCampaign'] }],

--- a/server/models/channels.js
+++ b/server/models/channels.js
@@ -30,6 +30,7 @@ function hash(entity) {
 }
 
 async function listDTAjax(context, params) {
+    shares.enforceGlobalPermission(context, 'manageChannels');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'channel', requiredOperations: ['view'] }],
@@ -44,6 +45,7 @@ async function listDTAjax(context, params) {
 }
 
 async function listWithCreateCampaignPermissionDTAjax(context, params) {
+    shares.enforceGlobalPermission(context, 'manageChannels');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'channel', requiredOperations: ['createCampaign'] }],
@@ -95,6 +97,7 @@ async function _getByTx(tx, context, key, id, withPermissions = true) {
 }
 
 async function getByIdTx(tx, context, id, withPermissions = true) {
+    shares.enforceGlobalPermission(context, 'manageChannels');
     await shares.enforceEntityPermissionTx(tx, context, 'channel', id, 'view');
 
     return await _getByTx(tx, context, 'id', id, withPermissions);
@@ -140,6 +143,7 @@ async function _validateAndPreprocess(tx, context, entity, isCreate) {
 }
 
 async function _createTx(tx, context, entity, content) {
+    shares.enforceGlobalPermission(context, 'manageChannels');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'namespace', entity.namespace, 'createCampaign');
 
@@ -169,6 +173,7 @@ async function create(context, entity) {
 }
 
 async function updateWithConsistencyCheck(context, entity) {
+    shares.enforceGlobalPermission(context, 'manageChannels');
     await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'channel', entity.id, 'edit');
 
@@ -198,6 +203,7 @@ async function updateWithConsistencyCheck(context, entity) {
 
 
 async function remove(context, id) {
+    shares.enforceGlobalPermission(context, 'manageChannels');
     await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'channel', id, 'delete');
 

--- a/server/models/lists.js
+++ b/server/models/lists.js
@@ -27,7 +27,6 @@ function hash(entity) {
 
 
 async function _listDTAjax(context, namespaceId, params) {
-    shares.enforceGlobalPermission(context, 'manageLists');
     const campaignEntityType = entitySettings.getEntityType('campaign');
 
     return await dtHelpers.ajaxListWithPermissions(

--- a/server/models/lists.js
+++ b/server/models/lists.js
@@ -86,7 +86,6 @@ async function listWithSegmentByCampaignDTAjax(context, campaignId, params) {
 }
 
 async function getByIdTx(tx, context, id) {
-    shares.enforceGlobalPermission(context, 'manageLists');
     await shares.enforceEntityPermissionTx(tx, context, 'list', id, 'view');
     const entity = await tx('lists').where('id', id).first();
     return entity;
@@ -100,7 +99,6 @@ async function getById(context, id) {
 }
 
 async function getByIdWithListFields(context, id) {
-    shares.enforceGlobalPermission(context, 'manageLists');
     return await knex.transaction(async tx => {
         const entity = await getByIdTx(tx, context, id);
         entity.permissions = await shares.getPermissionsTx(tx, context, 'list', id);
@@ -110,7 +108,6 @@ async function getByIdWithListFields(context, id) {
 }
 
 async function getByCidTx(tx, context, cid) {
-    shares.enforceGlobalPermission(context, 'manageLists');
     const entity = await tx('lists').where('cid', cid).first();
     if (!entity) {
         shares.throwPermissionDenied();
@@ -127,7 +124,6 @@ async function getByCid(context, cid) {
 }
 
 async function getByNamespaceIdTx(tx, context, namespaceId) {
-    shares.enforceGlobalPermission(context, 'manageLists');
   // FIXME - this methods is rather suboptimal if there are many lists. It quite needs permission caching in shares.js
 
   const rows = await tx('lists').where('namespace', namespaceId);

--- a/server/models/lists.js
+++ b/server/models/lists.js
@@ -69,7 +69,6 @@ async function listByNamespaceDTAjax(context, namespaceId, params) {
 }
 
 async function listWithSegmentByCampaignDTAjax(context, campaignId, params) {
-    shares.enforceGlobalPermission(context, 'manageLists');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'list', requiredOperations: ['view'] }],

--- a/server/models/lists.js
+++ b/server/models/lists.js
@@ -68,6 +68,7 @@ async function listByNamespaceDTAjax(context, namespaceId, params) {
 }
 
 async function listWithSegmentByCampaignDTAjax(context, campaignId, params) {
+    await shares.enforceEntityPermissionTx(tx, context, 'list', id, 'view');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'list', requiredOperations: ['view'] }],

--- a/server/models/lists.js
+++ b/server/models/lists.js
@@ -86,7 +86,6 @@ async function listWithSegmentByCampaignDTAjax(context, campaignId, params) {
 }
 
 async function getByIdTx(tx, context, id) {
-    await shares.enforceEntityPermissionTx(tx, context, 'list', id, 'view');
     const entity = await tx('lists').where('id', id).first();
     return entity;
 }

--- a/server/models/lists.js
+++ b/server/models/lists.js
@@ -27,6 +27,7 @@ function hash(entity) {
 
 
 async function _listDTAjax(context, namespaceId, params) {
+    shares.enforceGlobalPermission(context, 'manageLists');
     const campaignEntityType = entitySettings.getEntityType('campaign');
 
     return await dtHelpers.ajaxListWithPermissions(
@@ -68,6 +69,7 @@ async function listByNamespaceDTAjax(context, namespaceId, params) {
 }
 
 async function listWithSegmentByCampaignDTAjax(context, campaignId, params) {
+    shares.enforceGlobalPermission(context, 'manageLists');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'list', requiredOperations: ['view'] }],
@@ -84,6 +86,7 @@ async function listWithSegmentByCampaignDTAjax(context, campaignId, params) {
 }
 
 async function getByIdTx(tx, context, id) {
+    shares.enforceGlobalPermission(context, 'manageLists');
     await shares.enforceEntityPermissionTx(tx, context, 'list', id, 'view');
     const entity = await tx('lists').where('id', id).first();
     return entity;
@@ -97,6 +100,7 @@ async function getById(context, id) {
 }
 
 async function getByIdWithListFields(context, id) {
+    shares.enforceGlobalPermission(context, 'manageLists');
     return await knex.transaction(async tx => {
         const entity = await getByIdTx(tx, context, id);
         entity.permissions = await shares.getPermissionsTx(tx, context, 'list', id);
@@ -106,6 +110,7 @@ async function getByIdWithListFields(context, id) {
 }
 
 async function getByCidTx(tx, context, cid) {
+    shares.enforceGlobalPermission(context, 'manageLists');
     const entity = await tx('lists').where('cid', cid).first();
     if (!entity) {
         shares.throwPermissionDenied();
@@ -122,6 +127,7 @@ async function getByCid(context, cid) {
 }
 
 async function getByNamespaceIdTx(tx, context, namespaceId) {
+    shares.enforceGlobalPermission(context, 'manageLists');
   // FIXME - this methods is rather suboptimal if there are many lists. It quite needs permission caching in shares.js
 
   const rows = await tx('lists').where('namespace', namespaceId);
@@ -153,6 +159,7 @@ async function _validateAndPreprocess(tx, entity) {
 }
 
 async function create(context, entity) {
+    shares.enforceGlobalPermission(context, 'manageLists');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'namespace', entity.namespace, 'createList');
 
@@ -248,6 +255,7 @@ async function create(context, entity) {
 }
 
 async function updateWithConsistencyCheck(context, entity) {
+    shares.enforceGlobalPermission(context, 'manageLists');
     await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'list', entity.id, 'edit');
 
@@ -274,6 +282,7 @@ async function updateWithConsistencyCheck(context, entity) {
 }
 
 async function remove(context, id) {
+    shares.enforceGlobalPermission(context, 'manageLists');
     await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'list', id, 'delete');
 

--- a/server/models/namespaces.js
+++ b/server/models/namespaces.js
@@ -13,6 +13,7 @@ const dependencyHelpers = require('../lib/dependency-helpers');
 const allowedKeys = new Set(['name', 'description', 'namespace']);
 
 async function listTree(context) {
+    shares.enforceGlobalPermission(context, 'manageNamespaces');
     enforce(!context.user.admin, 'listTree is not supposed to be called by assumed admin');
 
     const entityType = entitySettings.getEntityType('namespace');
@@ -110,6 +111,7 @@ function hash(entity) {
 }
 
 async function getById(context, id) {
+    shares.enforceGlobalPermission(context, 'manageNamespaces');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'namespace', id, 'view');
         const entity = await tx('namespaces').where('id', id).first();
@@ -119,6 +121,7 @@ async function getById(context, id) {
 }
 
 async function getChildrenTx(tx, context, id) {
+    shares.enforceGlobalPermission(context, 'manageNamespaces');
     await shares.enforceEntityPermissionTx(tx, context, 'namespace', id, 'view');
 
     const entityType = entitySettings.getEntityType('namespace');
@@ -162,6 +165,7 @@ async function getChildrenTx(tx, context, id) {
 }
 
 async function createTx(tx, context, entity) {
+    shares.enforceGlobalPermission(context, 'manageNamespaces');
     enforce(entity.namespace, 'Parent namespace must be set');
 
     await shares.enforceEntityPermissionTx(tx, context, 'namespace', entity.namespace, 'createNamespace');
@@ -183,6 +187,7 @@ async function create(context, entity) {
 
 async function updateWithConsistencyCheck(context, entity) {
     enforce(entity.id !== 1 || entity.namespace === null, 'Cannot assign a parent to the root namespace.');
+    shares.enforceGlobalPermission(context, 'manageNamespaces');
 
     await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'namespace', entity.id, 'edit');
@@ -221,6 +226,7 @@ async function updateWithConsistencyCheck(context, entity) {
 
 async function remove(context, id) {
     enforce(id !== 1, 'Cannot delete the root namespace.');
+    shares.enforceGlobalPermission(context, 'manageNamespaces');
 
     await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'namespace', id, 'delete');

--- a/server/models/namespaces.js
+++ b/server/models/namespaces.js
@@ -119,7 +119,7 @@ async function getById(context, id) {
 }
 
 async function getChildrenTx(tx, context, id) {
-
+    await shares.enforceEntityPermissionTx(tx, context, 'namespace', id, 'view');
     const entityType = entitySettings.getEntityType('namespace');
 
     const extraKeys = em.get('models.namespaces.extraKeys', []);

--- a/server/models/namespaces.js
+++ b/server/models/namespaces.js
@@ -13,7 +13,6 @@ const dependencyHelpers = require('../lib/dependency-helpers');
 const allowedKeys = new Set(['name', 'description', 'namespace']);
 
 async function listTree(context) {
-    shares.enforceGlobalPermission(context, 'manageNamespaces');
     enforce(!context.user.admin, 'listTree is not supposed to be called by assumed admin');
 
     const entityType = entitySettings.getEntityType('namespace');
@@ -111,7 +110,6 @@ function hash(entity) {
 }
 
 async function getById(context, id) {
-    shares.enforceGlobalPermission(context, 'manageNamespaces');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'namespace', id, 'view');
         const entity = await tx('namespaces').where('id', id).first();
@@ -121,7 +119,6 @@ async function getById(context, id) {
 }
 
 async function getChildrenTx(tx, context, id) {
-    shares.enforceGlobalPermission(context, 'manageNamespaces');
     await shares.enforceEntityPermissionTx(tx, context, 'namespace', id, 'view');
 
     const entityType = entitySettings.getEntityType('namespace');

--- a/server/models/namespaces.js
+++ b/server/models/namespaces.js
@@ -119,7 +119,6 @@ async function getById(context, id) {
 }
 
 async function getChildrenTx(tx, context, id) {
-    await shares.enforceEntityPermissionTx(tx, context, 'namespace', id, 'view');
 
     const entityType = entitySettings.getEntityType('namespace');
 

--- a/server/models/reports.js
+++ b/server/models/reports.js
@@ -25,6 +25,7 @@ function hash(entity) {
 }
 
 async function getByIdWithTemplate(context, id, withPermissions = true) {
+    shares.enforceGlobalPermission(context, 'manageReports');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'report', id, 'view');
 
@@ -46,6 +47,7 @@ async function getByIdWithTemplate(context, id, withPermissions = true) {
 }
 
 async function listDTAjax(context, params) {
+    shares.enforceGlobalPermission(context, 'manageReports');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [
@@ -64,6 +66,7 @@ async function listDTAjax(context, params) {
 }
 
 async function create(context, entity) {
+    shares.enforceGlobalPermission(context, 'manageReports');
     let id;
     await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'namespace', entity.namespace, 'createReport');
@@ -85,6 +88,7 @@ async function create(context, entity) {
 }
 
 async function updateWithConsistencyCheck(context, entity) {
+    shares.enforceGlobalPermission(context, 'manageReports');
     await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'report', entity.id, 'edit');
         await shares.enforceEntityPermissionTx(tx, context, 'reportTemplate', entity.report_template, 'execute');
@@ -120,6 +124,7 @@ async function updateWithConsistencyCheck(context, entity) {
 }
 
 async function removeTx(tx, context, id) {
+    shares.enforceGlobalPermission(context, 'manageReports');
     await shares.enforceEntityPermissionTx(tx, context, 'report', id, 'delete');
 
     const report = await tx('reports').where('id', id).first();

--- a/server/models/reports.js
+++ b/server/models/reports.js
@@ -25,7 +25,6 @@ function hash(entity) {
 }
 
 async function getByIdWithTemplate(context, id, withPermissions = true) {
-    shares.enforceGlobalPermission(context, 'manageReports');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'report', id, 'view');
 
@@ -47,7 +46,6 @@ async function getByIdWithTemplate(context, id, withPermissions = true) {
 }
 
 async function listDTAjax(context, params) {
-    shares.enforceGlobalPermission(context, 'manageReports');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [
@@ -142,6 +140,7 @@ async function remove(context, id) {
 }
 
 async function updateFields(id, fields) {
+    shares.enforceGlobalPermission(context, 'manageReports');
     return await knex('reports').where('id', id).update(fields);
 }
 
@@ -150,6 +149,7 @@ async function listByState(state, limit) {
 }
 
 async function bulkChangeState(oldState, newState) {
+    shares.enforceGlobalPermission(context, 'manageReports');
     return await knex('reports').where('state', oldState).update('state', newState);
 }
 

--- a/server/models/reports.js
+++ b/server/models/reports.js
@@ -140,7 +140,6 @@ async function remove(context, id) {
 }
 
 async function updateFields(id, fields) {
-    shares.enforceGlobalPermission(context, 'manageReports');
     return await knex('reports').where('id', id).update(fields);
 }
 
@@ -149,7 +148,6 @@ async function listByState(state, limit) {
 }
 
 async function bulkChangeState(oldState, newState) {
-    shares.enforceGlobalPermission(context, 'manageReports');
     return await knex('reports').where('state', oldState).update('state', newState);
 }
 

--- a/server/models/send-configurations.js
+++ b/server/models/send-configurations.js
@@ -120,6 +120,7 @@ async function _validateAndPreprocess(tx, entity, isCreate) {
 
 
 async function create(context, entity) {
+    shares.enforceGlobalPermission(context, 'manageSendConfigurations');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'namespace', entity.namespace, 'createSendConfiguration');
 
@@ -138,6 +139,7 @@ async function create(context, entity) {
 }
 
 async function updateWithConsistencyCheck(context, entity) {
+    shares.enforceGlobalPermission(context, 'manageSendConfigurations');
     await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'sendConfiguration', entity.id, 'edit');
 
@@ -167,6 +169,7 @@ async function updateWithConsistencyCheck(context, entity) {
 }
 
 async function remove(context, id) {
+    shares.enforceGlobalPermission(context, 'manageSendConfigurations');
     if (id === getSystemSendConfigurationId()) {
         shares.throwPermissionDenied();
     }

--- a/server/models/shares.js
+++ b/server/models/shares.js
@@ -9,7 +9,7 @@ const interoperableErrors = require('../../shared/interoperable-errors');
 const log = require('../lib/log');
 const {getGlobalNamespaceId} = require('../../shared/namespaces');
 const {getAdminId} = require('../../shared/users');
-const { tMark } = require('../lib/translate');
+const { tUI } = require('../lib/translate');
 
 
 // TODO: This would really benefit from some permission cache connected to rebuildPermissions
@@ -451,7 +451,7 @@ async function regenerateRoleNamesTable() {
 
 
 function throwPermissionDenied() {
-    throw new interoperableErrors.PermissionDeniedError(tMark('permissionDenied'));
+    throw new interoperableErrors.PermissionDeniedError(tUI('permissionDenied', config.defaultLanguage));
 }
 
 async function removeDefaultShares(tx, user) {

--- a/server/models/shares.js
+++ b/server/models/shares.js
@@ -9,7 +9,6 @@ const interoperableErrors = require('../../shared/interoperable-errors');
 const log = require('../lib/log');
 const {getGlobalNamespaceId} = require('../../shared/namespaces');
 const {getAdminId} = require('../../shared/users');
-const { tUI } = require('../lib/translate');
 
 
 // TODO: This would really benefit from some permission cache connected to rebuildPermissions
@@ -451,7 +450,7 @@ async function regenerateRoleNamesTable() {
 
 
 function throwPermissionDenied() {
-    throw new interoperableErrors.PermissionDeniedError(tUI('permissionDenied', config.defaultLanguage));
+    throw new interoperableErrors.PermissionDeniedError('Permission denied');
 }
 
 async function removeDefaultShares(tx, user) {

--- a/server/models/shares.js
+++ b/server/models/shares.js
@@ -9,6 +9,8 @@ const interoperableErrors = require('../../shared/interoperable-errors');
 const log = require('../lib/log');
 const {getGlobalNamespaceId} = require('../../shared/namespaces');
 const {getAdminId} = require('../../shared/users');
+const { tMark } = require('../lib/translate');
+
 
 // TODO: This would really benefit from some permission cache connected to rebuildPermissions
 // A bit of the problem is that the cache would have to expunged as the result of other processes modifying entites/permissions
@@ -449,7 +451,7 @@ async function regenerateRoleNamesTable() {
 
 
 function throwPermissionDenied() {
-    throw new interoperableErrors.PermissionDeniedError('Permission denied');
+    throw new interoperableErrors.PermissionDeniedError(tMark('permissionDenied'));
 }
 
 async function removeDefaultShares(tx, user) {

--- a/server/models/shares.js
+++ b/server/models/shares.js
@@ -514,9 +514,7 @@ function checkGlobalPermission(context, requiredOperations) {
 }
 
 function enforceGlobalPermission(context, requiredOperations) {
-    const superadmin = ((context.user && context.user.role && config.roles.global[context.user.role]["admin"]) || false);
-
-    if (!superadmin && !checkGlobalPermission(context, requiredOperations)) {
+    if (!checkGlobalPermission(context, requiredOperations)) {
         throwPermissionDenied();
     }
 }

--- a/server/models/shares.js
+++ b/server/models/shares.js
@@ -515,7 +515,9 @@ function checkGlobalPermission(context, requiredOperations) {
 }
 
 function enforceGlobalPermission(context, requiredOperations) {
-    if (!checkGlobalPermission(context, requiredOperations)) {
+    const superadmin = ((context.user && context.user.role && config.roles.global[context.user.role]["admin"]) || false);
+
+    if (!superadmin && !checkGlobalPermission(context, requiredOperations)) {
         throwPermissionDenied();
     }
 }

--- a/server/models/templates.js
+++ b/server/models/templates.js
@@ -20,7 +20,6 @@ function hash(entity) {
 }
 
 async function getByIdTx(tx, context, id, withPermissions = true) {
-    shares.enforceGlobalPermission(context, 'manageTemplates');
     await shares.enforceEntityPermissionTx(tx, context, 'template', id, 'view');
     const entity = await tx('templates').where('id', id).first();
     entity.data = JSON.parse(entity.data);
@@ -39,7 +38,6 @@ async function getById(context, id, withPermissions = true) {
 }
 
 async function _listDTAjax(context, namespaceId, params) {
-    shares.enforceGlobalPermission(context, 'manageTemplates');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'template', requiredOperations: ['view'] }],

--- a/server/models/templates.js
+++ b/server/models/templates.js
@@ -20,6 +20,7 @@ function hash(entity) {
 }
 
 async function getByIdTx(tx, context, id, withPermissions = true) {
+    shares.enforceGlobalPermission(context, 'manageTemplates');
     await shares.enforceEntityPermissionTx(tx, context, 'template', id, 'view');
     const entity = await tx('templates').where('id', id).first();
     entity.data = JSON.parse(entity.data);
@@ -38,6 +39,7 @@ async function getById(context, id, withPermissions = true) {
 }
 
 async function _listDTAjax(context, namespaceId, params) {
+    shares.enforceGlobalPermission(context, 'manageTemplates');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'template', requiredOperations: ['view'] }],
@@ -70,6 +72,7 @@ async function _validateAndPreprocess(tx, entity) {
 }
 
 async function create(context, entity) {
+    shares.enforceGlobalPermission(context, 'manageTemplates');
     return await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'namespace', entity.namespace, 'createTemplate');
 
@@ -114,6 +117,7 @@ async function create(context, entity) {
 }
 
 async function updateWithConsistencyCheck(context, entity) {
+    shares.enforceGlobalPermission(context, 'manageTemplates');
     await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'template', entity.id, 'edit');
 
@@ -143,6 +147,7 @@ async function updateWithConsistencyCheck(context, entity) {
 }
 
 async function remove(context, id) {
+    shares.enforceGlobalPermission(context, 'manageTemplates');
     await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'template', id, 'delete');
 

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -37,7 +37,6 @@ function hash(entity) {
 }
 
 async function _getByTx(tx, context, key, value, extraColumns = []) {
-    shares.enforceGlobalPermission(context, 'manageUsers');
     const columns = ['id', 'username', 'name', 'email', 'namespace', 'role', ...extraColumns];
 
     const user = await tx('users').select(columns).where(key, value).first();
@@ -110,7 +109,6 @@ async function serverValidate(context, data, isOwnAccount) {
 }
 
 async function listDTAjax(context, params) {
-    shares.enforceGlobalPermission(context, 'manageUsers');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'namespace', requiredOperations: ['manageUsers'] }],

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -37,6 +37,7 @@ function hash(entity) {
 }
 
 async function _getByTx(tx, context, key, value, extraColumns = []) {
+    shares.enforceGlobalPermission(context, 'manageUsers');
     const columns = ['id', 'username', 'name', 'email', 'namespace', 'role', ...extraColumns];
 
     const user = await tx('users').select(columns).where(key, value).first();
@@ -109,6 +110,7 @@ async function serverValidate(context, data, isOwnAccount) {
 }
 
 async function listDTAjax(context, params) {
+    shares.enforceGlobalPermission(context, 'manageUsers');
     return await dtHelpers.ajaxListWithPermissions(
         context,
         [{ entityTypeId: 'namespace', requiredOperations: ['manageUsers'] }],
@@ -165,6 +167,7 @@ async function _validateAndPreprocess(tx, entity, isCreate, isOwnAccount) {
 }
 
 async function create(context, user) {
+    shares.enforceGlobalPermission(context, 'manageUsers');
     let id;
     await knex.transaction(async tx => {
         await shares.enforceEntityPermissionTx(tx, context, 'namespace', user.namespace, 'manageUsers');
@@ -192,6 +195,7 @@ async function create(context, user) {
 }
 
 async function updateWithConsistencyCheck(context, user, isOwnAccount) {
+    shares.enforceGlobalPermission(context, 'manageUsers');
     await knex.transaction(async tx => {
         const existing = await tx('users').where('id', user.id).first();
         if (!existing) {
@@ -240,6 +244,7 @@ async function updateWithConsistencyCheck(context, user, isOwnAccount) {
 async function remove(context, userId) {
     enforce(userId !== 1, 'Admin cannot be deleted');
     enforce(context.user.id !== userId, 'User cannot delete himself/herself');
+    shares.enforceGlobalPermission(context, 'manageUsers');
 
     await knex.transaction(async tx => {
         const existing = await tx('users').where('id', userId).first();


### PR DESCRIPTION
Added new global permissions: **manageLists, manageChannels, manageTemplates, manageCampaigns, manageReports, manageApi, manageSendConfigurations, manageNamespaces** to already defined **manageBlacklist, manageSettings** and change the name of **displayManageUsers** to **manageUsers**

If not assign manageChannels to the rol of user, the channel menu will be hide, for example.

Also, if user is a superadmin (he has the admin:true in his configuration) always show all menu entries.

 