### PR TITLE
(v2) Fix subscription widget

### DIFF
--- a/server/routes/subscription.js
+++ b/server/routes/subscription.js
@@ -331,14 +331,15 @@ router.getAsync('/:cid/widget', cors(corsOptions), async (req, res) => {
         subscribeUrl: getPublicUrl(`subscription/${list.cid}/subscribe`),
         hasPubkey: !!configItems.pgpPrivateKey,
         customFields: await fields.forHbs(contextHelpers.getAdminContext(), list.id),
-        template: {},
+        template: 'subscription/widget-subscribe.hbs',
         layout: null,
     };
 
     await injectCustomFormData(req.query.fid || list.default_form, 'web_subscribe', data);
 
-    const renderAsync = bluebird.promisify(res.render.bind(res));
-    const html = await renderAsync('subscription/widget-subscribe', data);
+    const htmlRenderer = await tools.getTemplate(data.template, req.locale);
+
+    const html = htmlRenderer(data);
 
     const response = {
         data: {

--- a/server/routes/subscription.js
+++ b/server/routes/subscription.js
@@ -282,7 +282,9 @@ router.postAsync('/:cid/subscribe', passport.parseForm, corsOrCsrfProtection, as
     if (existingSubscription && existingSubscription.status === SubscriptionStatus.SUBSCRIBED) {
         await mailHelpers.sendAlreadySubscribed(req.locale, list, email, existingSubscription);
         if (req.xhr) {
-            throw new Error(tUI('listEmailAddressAlreadyRegistered', req.locale, {list: list.name}));
+            return res.status(200).json({
+                msg: tUI('pleaseConfirmSubscription', req.locale)
+            });
         }
         res.redirect('/subscription/' + encodeURIComponent(req.params.cid) + '/confirm-subscription-notice');
 

--- a/server/routes/subscription.js
+++ b/server/routes/subscription.js
@@ -281,6 +281,9 @@ router.postAsync('/:cid/subscribe', passport.parseForm, corsOrCsrfProtection, as
 
     if (existingSubscription && existingSubscription.status === SubscriptionStatus.SUBSCRIBED) {
         await mailHelpers.sendAlreadySubscribed(req.locale, list, email, existingSubscription);
+        if (req.xhr) {
+            throw new Error(tUI('listEmailAddressAlreadyRegistered', req.locale, {list: list.name}));
+        }
         res.redirect('/subscription/' + encodeURIComponent(req.params.cid) + '/confirm-subscription-notice');
 
     } else {
@@ -325,7 +328,7 @@ router.getAsync('/:cid/widget', cors(corsOptions), async (req, res) => {
         title: list.name,
         cid: list.cid,
         publicKeyUrl: getTrustedUrl('subscription/publickey'),
-        subscribeUrl: getTrustedUrl(`subscription/${list.cid}/subscribe`),
+        subscribeUrl: getPublicUrl(`subscription/${list.cid}/subscribe`),
         hasPubkey: !!configItems.pgpPrivateKey,
         customFields: await fields.forHbs(contextHelpers.getAdminContext(), list.id),
         template: {},


### PR DESCRIPTION
Fixes the subscription widget! Had an invalid URL and CORS doesn't allow redirects so needed to specify a JSON API response in the case of an existing subscription on an email.

I wasn't sure if I was supposed to use `tMark` or `tUI` here, what's the main difference in use? What happens when a translation doesn't exist for other languages? Do we have to add translations to each language?

Closes https://github.com/Mailtrain-org/mailtrain/issues/944

This also fixes the Email field label not appearing! Needed to use the template rendering to handle the translations.