### PR TITLE
Fix plaintext rendering

### DIFF
--- a/client/src/templates/helpers.js
+++ b/client/src/templates/helpers.js
@@ -700,7 +700,7 @@ export function getEditForm(owner, typeKey, prefix = '') {
                 height="400px"
                 mode="text"
                 label={t('templateContentPlainText')}
-                help={<Trans i18nKey="toExtractTheTextFromHtmlClickHerePlease">To extract the text from HTML click <ActionLink onClickAsync={::owner.extractPlainText}>here</ActionLink>. Please note that your existing plaintext in the field above will be overwritten. This feature uses the <a href="http://premailer.dialect.ca/api">Premailer API</a>, a third party service. Their Terms of Service and Privacy Policy apply.</Trans>}
+                help={<Trans i18nKey="toExtractTheTextFromHtmlClickHerePlease">To extract the text from HTML click <ActionLink onClickAsync={::owner.extractPlainText}>here</ActionLink>. Please note that your existing plaintext in the field above will be overwritten.</Trans>}
             />
         </div>
     );

--- a/locales/de-DE/common.json
+++ b/locales/de-DE/common.json
@@ -955,7 +955,7 @@
   "contentOfAnRssEntry": "Inhalt eines RSS Eintrag",
   "rssEntrySummary": "RSS Eintrag Zusammenfassung",
   "rssEntryImageUrl": "RSS Eintrag Bild URL",
-  "toExtractTheTextFromHtmlClickHerePlease": "<1>Hier</1> klicken den Text aus dem HTML zu extrahieren. Hinweis: der bestehende Klartext wird überschrieben. Dieses Feature nutzt die <3>Premailer API</3>. Es gelten die Datenschutzbestimmungen des Anbieters.",
+  "toExtractTheTextFromHtmlClickHerePlease": "<1>Hier</1> klicken den Text aus dem HTML zu extrahieren. Hinweis: der bestehende Klartext wird überschrieben.",
   "mosaicoTemplateUpdated": "Mosaico Vorlage aktualisiert",
   "mosaicoTemplateCreated": "Mosaico Vorlage erstellt",
   "deletingMosaicoTemplate": "Mosaico Vorlage wird gelöscht ...",

--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -961,7 +961,7 @@
   "contentOfAnRssEntry": "Content of an RSS entry",
   "rssEntrySummary": "RSS entry summary",
   "rssEntryImageUrl": "RSS entry image URL",
-  "toExtractTheTextFromHtmlClickHerePlease": "To extract the text from HTML click <1>here</1>. Please note that your existing plaintext in the field above will be overwritten. This feature uses the <3>Premailer     API</3>, a third party service. Their Terms of Service and Privacy Policy apply.",
+  "toExtractTheTextFromHtmlClickHerePlease": "To extract the text from HTML click <1>here</1>. Please note that your existing plaintext in the field above will be overwritten.",
   "mosaicoTemplateUpdated": "Mosaico template updated",
   "mosaicoTemplateCreated": "Mosaico template created",
   "deletingMosaicoTemplate": "Deleting Mosaico template ...",

--- a/locales/es-ES/common.json
+++ b/locales/es-ES/common.json
@@ -985,7 +985,7 @@
   "contentOfAnRssEntry": "Contenido de la entrada RSS",
   "rssEntrySummary": "Resumen de la entrada RSS",
   "rssEntryImageUrl": "Enlace a la imágen RSS",
-  "toExtractTheTextFromHtmlClickHerePlease": "To extract the text from HTML click <1>here</1>. Please note that your existing plaintext in the field above will be overwritten. This feature uses the <3>Premailer     API</3>, a third party service. Their Terms of Service and Privacy Policy apply.",
+  "toExtractTheTextFromHtmlClickHerePlease": "To extract the text from HTML click <1>here</1>. Please note that your existing plaintext in the field above will be overwritten.",
   "mosaicoTemplateUpdated": "Plantilla Mosaico actualizada",
   "mosaicoTemplateCreated": "Plantilla Mosaico creada",
   "deletingMosaicoTemplate": "Borrando plantilla Mosaico ...",

--- a/locales/fr-FR/common.json
+++ b/locales/fr-FR/common.json
@@ -956,7 +956,7 @@
   "contentOfAnRssEntry": "Contenu d'une entrée RSS",
   "rssEntrySummary": "Résumé de l'entrée RSS",
   "rssEntryImageUrl": "URL de l'image d'entrée RSS",
-  "toExtractTheTextFromHtmlClickHerePlease": "Pour extraire le texte de HTML, cliquez <1> ici </1>. Veuillez noter que votre texte en clair existant dans le champ ci-dessus sera écrasé. Cette fonctionnalité utilise l '<3> API Premailer </3>, un service tiers. Leurs conditions d'utilisation et leur politique de confidentialité s'appliquent. ",
+  "toExtractTheTextFromHtmlClickHerePlease": "Pour extraire le texte de HTML, cliquez <1> ici </1>. Veuillez noter que votre texte en clair existant dans le champ ci-dessus sera écrasé.",
   "mosaicoTemplateUpdated": "Modèle Mosaico mis à jour",
   "mosaicoTemplateCreated": "Modèle Mosaico créé",
   "deletingMosaicoTemplate": "Suppression du modèle Mosaico ...",

--- a/locales/pt-BR/common.json
+++ b/locales/pt-BR/common.json
@@ -1028,7 +1028,7 @@
   "contentOfAnRssEntry": "Conteúdo de uma entrada RSS",
   "rssEntrySummary": "Resumo da entrada do RSS",
   "rssEntryImageUrl": "URL da imagem de entrada RSS",
-  "toExtractTheTextFromHtmlClickHerePlease": "Para extrair o texto do HTML, clique <1> aqui </ 1>. Observe que o texto original existente no campo acima será sobrescrito. Esse recurso usa a <3> Premailer API </ 3>, uma serviço de terceiros. Os seus Termos de Serviço e Política de Privacidade são aplicáveis. ",
+  "toExtractTheTextFromHtmlClickHerePlease": "Para extrair o texto do HTML, clique <1> aqui </ 1>. Observe que o texto original existente no campo acima será sobrescrito.",
   "mosaicoTemplateUpdated": "Mosaico template updated",
   "mosaicoTemplateUpdated - TODO: update line above and then delete this line to mark that the translation has been fixed": "Mosaico template updated",
   "mosaicoTemplateCreated": "Mosaico template created",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12162,15 +12162,6 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
-    "premailer-api": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/premailer-api/-/premailer-api-1.0.4.tgz",
-      "integrity": "sha1-hz9A/DiN3IgG81uY3NKymTeKh08=",
-      "requires": {
-        "request": "^2.72.0",
-        "underscore": "^1.8.3"
-      }
-    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -13431,11 +13422,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
-    },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "underscore.string": {
       "version": "3.3.5",

--- a/server/package.json
+++ b/server/package.json
@@ -102,7 +102,6 @@
     "openpgp": "^4.7.2",
     "passport": "^0.4.1",
     "passport-local": "^1.0.0",
-    "premailer-api": "^1.0.4",
     "request": "^2.88.0",
     "request-promise": "^4.2.5",
     "serve-favicon": "^2.5.0",

--- a/server/routes/rest/editors.js
+++ b/server/routes/rest/editors.js
@@ -3,23 +3,14 @@
 const passport = require('../../lib/passport');
 
 const bluebird = require('bluebird');
-const premailerApi = require('premailer-api');
-const premailerPrepareAsync = bluebird.promisify(premailerApi.prepare.bind(premailerApi));
+const htmlToText = require('html-to-text');
 
 const router = require('../../lib/router-async').create();
 
 router.postAsync('/html-to-text', passport.loggedIn, passport.csrfProtection, async (req, res) => {
-    if (!req.body.html) {
-        return res.json({text: ''}); // Premailer crashes very hard when html is empty
-    }
+    const email = htmlToText.fromString(req.body.html, {wordwrap: 130});
 
-    const email = await premailerPrepareAsync({
-        html: req.body.html,
-        fetchHTML: false
-    });
-
-    res.json({text: email.text.replace(/%5B/g, '[').replace(/%5D/g, ']')});
-
+    res.json({text: email});
 });
 
 module.exports = router;


### PR DESCRIPTION
Uses the plaintext rendering method used for sending out campaigns that [already existed](https://github.com/Mailtrain-org/mailtrain/blob/development/server/lib/message-sender.js#L722) in the app since Premailer API was shut down.

Fixes https://github.com/Mailtrain-org/mailtrain/issues/850 and https://github.com/Mailtrain-org/mailtrain/issues/943