### PR TITLE
Save values from group options on CSV import. Fix #638

### DIFF
--- a/server/models/subscriptions.js
+++ b/server/models/subscriptions.js
@@ -661,6 +661,8 @@ async function createTxWithGroupedFieldsMap(tx, context, listId, groupedFieldsMa
 
     const allowedKeys = getAllowedKeys(groupedFieldsMap);
 
+    groupSubscription(groupedFieldsMap, entity);
+
     await _validateAndPreprocess(tx, listId, groupedFieldsMap, entity, meta, true);
 
     const filteredEntity = filterObject(entity, allowedKeys);


### PR DESCRIPTION
This PR fixes #638. 
When importing a CSV file, the columns mapped to Option fields with a containing group are overwritten as false.

Steps to reproduce the bug:
1. Create a List
2. Go to Fields and a add a `Checkboxes (from options)` field. [for example, let's call it `PARTICIPANT_YEAR`]
3. Add another field, now an "Option" one. Mark the checkbox `Belongs to checkbox / dropdown / radio group`, and in `Containing Group` select the field you created on step two. [for example, `2020`]
4. Create a simple CSV file, with three columns: `email`, `name` and `participant_2020`. Add a row with some data - in the last column you can put `1` or `yes`.
5. Try to import the file, mapping the new column [`participant_2020` in the example] to the Option field created in step three.
The subscriber will be added or updated, but the checkbox data will be in blank.

After merging this commit, repeat step 5 and see the values are correctly saved. 