### PR TITLE
Allow passing email parameter when subscribing, as in mailtrain v1

### DIFF
--- a/server/models/fields.js
+++ b/server/models/fields.js
@@ -648,7 +648,6 @@ function forHbsWithFieldsGrouped(fieldsGrouped, subscription) { // assumes group
         column: 'email',
         key: 'EMAIL',
         typeSubscriptionEmail: true,
-        value: subscription ? subscription.email : '',
         order_subscribe: -1,
         order_manage: -1
     }];

--- a/server/routes/subscription.js
+++ b/server/routes/subscription.js
@@ -162,6 +162,7 @@ router.getAsync('/confirm/unsubscribe/:cid', async (req, res) => {
 async function _renderSubscribe(req, res, list, subscription) {
     const data = {};
     data.email = subscription && subscription.email;
+    data.email2 = req.query.email;
     data.layout = 'subscription/layout';
     data.title = list.name;
     data.cid = list.cid;

--- a/server/views/subscription/partials/subscription-custom-fields.hbs
+++ b/server/views/subscription/partials/subscription-custom-fields.hbs
@@ -2,14 +2,14 @@
 
     {{#if typeSubscriptionEmail}}
         <div class="form-group email">
-            <label for="EMAIL">{{#translate}}emailAddress-2{{/translate}}</label>
+            <label for="{{key}}">{{#translate}}emailAddress-2{{/translate}}</label>
             {{#if ../isManagePreferences}}
                 <div class="input-group">
-                    <input type="email" name="EMAIL" id="email" placeholder="" value="{{../email}}" readonly>
+                    <input type="email" name="{{key}}" id="email" placeholder="" value="{{../email}}" readonly>
                     <div class="input-group-addon"><a href="/subscription/{{../lcid}}/manage-address/{{../cid}}">{{#translate}}wantToChangeIt?{{/translate}}</a></div>
                 </div>
             {{else}}
-                <input type="email" name="EMAIL" id="email" placeholder="" value="{{../email}}" required>
+                <input type="email" name="{{key}}" id="email" placeholder="" value="{{../email2}}" required>
             {{/if}}
             <small class="form-text text-muted">{{help}}</small>
         </div>


### PR DESCRIPTION
I used this feature and after migrating to v2-beta I missed it. It looks like it got lost during the refactor.
