### PR TITLE
Increase MySQL Packet size to 32MB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 services:
   mysql:
     image: mysql:5.7
+    command: --max_allowed_packet=32505856
     environment:
       - MYSQL_ROOT_PASSWORD=mailtrain
       - MYSQL_DATABASE=mailtrain


### PR DESCRIPTION
The Mailtrain config allows changing the allowed attachment size
from the default 2MB. I attempted to increase this to 8MB, to allow
our organization to use MailTrain to distribute PDF versions of our
hardcopy newsletter, and while MailTrain allowed the change, the UI
puked with MySQL packet too large errors.

This appears to be because the default MySQL packet is 4MB, where
packet refers to a single MySQL transaction, so while MailTrain would
accept the 5MB attachment, when it tried to insert the attachment into
the database, the single transaction to perform that insert was too
large.

This patch sets the MySQL Docker compose config to allow 32MB packets,
which should be plenty for the <10MB attachment size generally allowed
on the Internet, plus the MySQL overhead around the attachment during
the INSERT.