### PR TITLE
Fix GET /lists/:email API call to return list subscription status

### DIFF
--- a/lib/models/lists.js
+++ b/lib/models/lists.js
@@ -86,6 +86,7 @@ module.exports.getListsWithEmail = (email, callback) => {
                     }
                     if (sub) {
                         results.push(list.id);
+                        list.status = sub.status;
                     }
                     if (index === arr.length - 1) {
                         return callback(null, lists.filter(list => results.includes(list.id)));


### PR DESCRIPTION
`GET /api/lists/:email` now returns subscription status, e.g.

```
    {"data":[{"id":3,"name":"Test Newsletter","status":2}]}
```

This fixes https://github.com/Mailtrain-org/mailtrain/issues/903 for v1.