### PR TITLE
(V2) Force light mode in mosaico preset (iOS-Mail)

### DIFF
--- a/client/static/mosaico/templates/versafix-1/template-versafix-1.html
+++ b/client/static/mosaico/templates/versafix-1/template-versafix-1.html
@@ -4,6 +4,8 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="initial-scale=1.0">
   <meta name="format-detection" content="telephone=no">
+  <meta name="color-scheme" content="light">
+  <meta name="supported-color-schemes" content="light">
   <title style="-ko-bind-text: @titleText">TITLE</title>
   <style type="text/css">
     @supports -ko-blockdefs {


### PR DESCRIPTION
Force iOS-Mail to use provided colours, even if the device is in darkmode to prevent unreadable mailings.

### Without fix:
![image](https://user-images.githubusercontent.com/22852640/101412447-eaeb8500-38e2-11eb-8761-be04c49a52dd.png)
### With fix:
![image](https://user-images.githubusercontent.com/22852640/101412529-0f476180-38e3-11eb-9357-70c5aadfbc13.png)
