### PR TITLE
Adding Support for custom redis and MySQL port configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ variables (e.g. `URL_BASE_TRUSTED=https://mailtrain.domain.com (and more env-var
 | MONGO_HOST       | sets mongo host (default: mongo)                                      |
 | WITH_REDIS       | enables or disables redis (default: true)                             |
 | REDIS_HOST       | sets redis host (default: redis)                                      |
+| REDIS_PORT       | sets redis host (default: 6379)                                       |
 | MYSQL_HOST       | sets mysql host (default: mysql)                                      |
+| MYSQL_PORT       | sets mysql port (default: 3306)                                       |
 | MYSQL_DATABASE   | sets mysql database (default: mailtrain)                              |
 | MYSQL_USER       | sets mysql user (default: mailtrain)                                  |
 | MYSQL_PASSWORD   | sets mysql password (default: mailtrain)                              |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,7 +29,9 @@ LDAP_METHOD=${LDAP_METHOD:-'ldapjs'}
 MONGO_HOST=${MONGO_HOST:-'mongo'}
 WITH_REDIS=${WITH_REDIS:-'true'}
 REDIS_HOST=${REDIS_HOST:-'redis'}
+REDIS_PORT=${REDIS_PORT:-'6379'}
 MYSQL_HOST=${MYSQL_HOST:-'mysql'}
+MYSQL_PORT=${MYSQL_PORT:-'3306'}
 MYSQL_DATABASE=${MYSQL_DATABASE:-'mailtrain'}
 MYSQL_USER=${MYSQL_USER:-'mailtrain'}
 MYSQL_PASSWORD=${MYSQL_PASSWORD:-'mailtrain'}
@@ -68,10 +70,12 @@ mysql:
   database: $MYSQL_DATABASE
   user: $MYSQL_USER
   password: $MYSQL_PASSWORD
+  port: $MYSQL_PORT
 
 redis:
   enabled: $WITH_REDIS
   host: $REDIS_HOST
+  port: $REDIS_PORT
 
 builtinZoneMTA:
   enabled: $WITH_ZONE_MTA
@@ -130,11 +134,11 @@ fi
 
 # Wait for the other services to start
 echo 'Info: Waiting for MySQL Server'
-while ! nc -z $MYSQL_HOST 3306; do sleep 1; done
+while ! nc -z $MYSQL_HOST $MYSQL_PORT; do sleep 1; done
 
 if [ "$WITH_REDIS" = "true" ]; then
   echo 'Info: Waiting for Redis Server'
-  while ! nc -z $REDIS_HOST 6379; do sleep 1; done
+  while ! nc -z $REDIS_HOST $REDIS_PORT; do sleep 1; done
 fi
 
 if [ "$WITH_ZONE_MTA" = "true" ]; then


### PR DESCRIPTION
This adds support for non standard Redis and MySQL ports in config file and docker entry 
This kind of config typically is found in managed services like DigitalOcean