### PR TITLE
Fixes double quote in dbCheck support when `ANSI_QUOTES`is  disabled 

### DIFF
--- a/server/lib/dbcheck.js
+++ b/server/lib/dbcheck.js
@@ -69,7 +69,7 @@ function getSchemaVersion(callback) {
             return callback(err);
         }
 
-        connection.query('SHOW TABLES LIKE "knex_migrations"', (err, rows) => {
+        connection.query("SHOW TABLES LIKE 'knex_migrations'", (err, rows) => {
             if (err) {
                 return callback(err);
             }


### PR DESCRIPTION
This fixes (#1005) issue with knex migration when `sql_mode` does not have `ANSI_QUOTES` included. 

[Ref MySQL 8 docs ](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_ansi_quotes)