### PR TITLE
Fix null template value

### DIFF
--- a/server/app-builder.js
+++ b/server/app-builder.js
@@ -123,6 +123,10 @@ hbs.registerHelper('flash_messages', function () { // eslint-disable-line prefer
 
 async function createApp(appType) {
     const app = express();
+    // add healthcheck endpoint
+    app.all('/_health', (req, res, next) => {
+        res.send('');
+    });
 
     function install404Fallback(url) {
         app.use(url, (req, res, next) => {

--- a/server/lib/message-sender.js
+++ b/server/lib/message-sender.js
@@ -363,6 +363,8 @@ class MessageSender {
 
             if (this.tagLanguage) {
                 subject = tools.formatCampaignTemplate(this.subject, this.tagLanguage, mergeTags, false, campaign, list, subscriptionGrouped);
+            } else if (campaign.source === CampaignSource.URL) {
+                subject = tools.formatCampaignTemplate(this.subject, 'simple', mergeTags, false, campaign, list, subscriptionGrouped);
             }
 
             headers = {

--- a/server/lib/message-sender.js
+++ b/server/lib/message-sender.js
@@ -227,7 +227,7 @@ class MessageSender {
 
             html = response.body;
             text = '';
-            renderTags = false;
+            renderTags = true;
         }
 
         const attachments = this.attachments.slice();
@@ -249,8 +249,10 @@ class MessageSender {
                 html = await links.updateLinks(html, this.tagLanguage, mergeTags, campaign, list, subscriptionGrouped);
             }
 
-            // When no list and subscriptionGrouped is provided, formatCampaignTemplate works the same way as formatTemplate
-            html = tools.formatCampaignTemplate(html, this.tagLanguage, mergeTags, true, campaign, list, subscriptionGrouped);
+            if (campaign.source !== CampaignSource.URL) {
+              // When no list and subscriptionGrouped is provided, formatCampaignTemplate works the same way as formatTemplate
+              html = tools.formatCampaignTemplate(html, this.tagLanguage, mergeTags, true, campaign, list, subscriptionGrouped);
+            }
         }
 
         const generateText = !(text || '').trim();

--- a/server/lib/tools.js
+++ b/server/lib/tools.js
@@ -166,7 +166,7 @@ function _formatTemplateSimple(source, mergeTags, isHTML) {
             }
         }
 
-        if (value === undefined) { // in RSS it may happen that the key is present, but the value is undefined
+        if (typeof value === undefined || !value) { // in RSS it may happen that the key is present, but the value is undefined
             return '';
         }
 

--- a/server/models/links.js
+++ b/server/models/links.js
@@ -140,7 +140,7 @@ async function addOrGet(campaignId, url) {
     }
 }
 
-async function updateLinks(source, tagLanguage, mergeTags, campaign, list, subscription) {
+async function updateLinks(source, tagLanguage='simple', mergeTags, campaign, list, subscription) {
     if ((campaign.open_tracking_disabled && campaign.click_tracking_disabled) || !source || !source.trim()) {
         // tracking is disabled, do not modify the message
         return source;


### PR DESCRIPTION
Adding a fix for the following error:
```
verb TypeError: Cannot read property 'replace' of null
    at getValue (/app/server/lib/tools.js:174:65)
    at source.replace (/app/server/lib/tools.js:181:21)
    at String.replace (<anonymous>)
    at _formatTemplateSimple (/app/server/lib/tools.js:180:19)
    at formatTemplate (/app/server/lib/tools.js:199:16)
    at Object.formatCampaignTemplate (/app/server/lib/tools.js:150:12)
    at MessageSender._getMessage (/app/server/lib/message-sender.js:254:28) 
```

The check on line 169 needed improvement