### PR TITLE
improved value check

### DIFF
--- a/server/lib/tools.js
+++ b/server/lib/tools.js
@@ -166,7 +166,7 @@ function _formatTemplateSimple(source, mergeTags, isHTML) {
             }
         }
 
-        if (value === undefined) { // in RSS it may happen that the key is present, but the value is undefined
+        if (typeof value === "undefined" || !value) { // in RSS it may happen that the key is present, but the value is undefined
             return '';
         }
 


### PR DESCRIPTION
fix for
```
verb TypeError: Cannot read property 'replace' of null
    at getValue (/app/server/lib/tools.js:174:65)
    at source.replace (/app/server/lib/tools.js:181:21)
    at String.replace (<anonymous>)
    at _formatTemplateSimple (/app/server/lib/tools.js:180:19)
    at formatTemplate (/app/server/lib/tools.js:199:16)
    at Object.formatCampaignTemplate (/app/server/lib/tools.js:150:12)
    at MessageSender._getMessage (/app/server/lib/message-sender.js:254:28) 
```