### PR TITLE
Invalid dateformat default

### DIFF
--- a/client/src/lists/fields/CUD.js
+++ b/client/src/lists/fields/CUD.js
@@ -91,7 +91,7 @@ export default class CUD extends Component {
         data.isInGroup = data.group !== null;
 
         data.enumOptions = '';
-        data.dateFormat = DateFormat.EUR;
+        data.dateFormat = DateFormat.EU;
         data.renderTemplate = '';
 
         switch (data.type) {


### PR DESCRIPTION
The default refers to the non-existent `EUR` date format (should be `EU`; the string is `eur`, however).