### PR TITLE
Actually do ignore node_modules everywhere

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-node_modules/
+**/node_modules/
 docs/
 Dockerfile
 *.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN cd /app/shared && npm install --production
 RUN cd /app/server && npm install --production
 RUN cd /app/zone-mta && npm install --production
 
-# Later, copy the app files. That improves development speed as buiding the Docker image will not have
+# Later, copy the app files. That improves development speed as building the Docker image will not have
 # to download and install all the NPM dependencies every time there's a change in the source code
 COPY . /app
 


### PR DESCRIPTION
`.dockerignore` matching rules differ from `.gitignore`, unfortunately. So, all `node_modules` directories (~750 MB) are sent to the docker daemon on every `docker build`.

Drive-by: Typo