### PR TITLE
Bugfix of wrong/uninitialized var name (cachedFiles)

### DIFF
--- a/server/lib/file-cache.js
+++ b/server/lib/file-cache.js
@@ -152,7 +152,7 @@ async function _fileCache(typeId, cacheConfig, keyGen) {
                     if (fileStream) {
                         fileStream.destroy(err);
                         fs.unlink(tmpFilePath, () => {
-                            cachedFiles.delete(key);
+                            fileCaches.delete(key);
                             callback();
                         });
                     } else {


### PR DESCRIPTION
I think `fileCaches.delete(key);` is correct at this place to remove a cache file entry from the according cache map (while cachedFiles is not defined).