### PR TITLE
Security Risk: Warning about security risk and Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,12 @@ Alternatively, you can just declare them there leaving their value empty
 value can be provided via a file called `.env` or via environment 
 variables (e.g. `URL_BASE_TRUSTED=https://mailtrain.domain.com (and more env-vars..) docker-compose -f docker-compose.yml build (or up)`)  
 
+#### !!!WARNING!!! Always set ADMIN_PASSWORD, as it will leave your instance otherwise vurnerable with the default password being `test`!
+
 | Parameter        | Description |
 | ---------        | ----------- |
+| ADMIN_PASSWORD | sets Admin Password, Admin users name can be changed, but password will always be overwritten by this, please set it always, as it otherwise defaults to `test` |
+| ADMIN_ACCESS_TOKEN | sets Access Token for API, this is optional |
 | PORT_TRUSTED     | sets the trusted port of the instance (default: 3000)                 |
 | PORT_SANDBOX     | sets the sandbox port of the instance (default: 3003)                 |
 | PORT_PUBLIC      | sets the public port of the instance (default: 3004)                  |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,7 +46,6 @@ POOL_NAME=${POOL_NAME:-$(hostname)}
 LOG_LEVEL=${LOG_LEVEL:-'info'}
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-'test'}
 ADMIN_ACCESS_TOKEN=${ADMIN_ACCESS_TOKEN:-''}
-DEFAULT_LANGUAGE=${DEFAULT_LANGUAGE:-'en-US'}
 
 # Warning for users that already rely on the MAILTRAIN_SETTING variable
 # Can probably be removed in the future.
@@ -99,8 +98,6 @@ queue:
 
 log:
   level: $LOG_LEVEL
-
-defaultLanguage: $DEFAULT_LANGUAGE
 
 EOT
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,6 +46,7 @@ POOL_NAME=${POOL_NAME:-$(hostname)}
 LOG_LEVEL=${LOG_LEVEL:-'info'}
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-'test'}
 ADMIN_ACCESS_TOKEN=${ADMIN_ACCESS_TOKEN:-''}
+DEFAULT_LANGUAGE=${DEFAULT_LANGUAGE:-'en-US'}
 
 # Warning for users that already rely on the MAILTRAIN_SETTING variable
 # Can probably be removed in the future.
@@ -98,6 +99,9 @@ queue:
 
 log:
   level: $LOG_LEVEL
+
+defaultLanguage: $DEFAULT_LANGUAGE
+
 EOT
 
     # Manage LDAP if enabled

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -98,7 +98,6 @@ queue:
 
 log:
   level: $LOG_LEVEL
-
 EOT
 
     # Manage LDAP if enabled


### PR DESCRIPTION
Warning about not setting ADMIN_PASSWORD being set to `test` if not set, being a great security hole.
And including ADMIN_PASSWORD and ADMIN_TOKEN into the table.
Don't know if ADMIN_ACCESS_TOKEN being empty makes it that none is set and optional or being another security hole.