### PR TITLE
Fixed the issue 701, The operator "campaign_links.subscription" is not permitted

### DIFF
--- a/server/services/triggers.js
+++ b/server/services/triggers.js
@@ -81,7 +81,7 @@ async function run() {
                                     .where('campaign_links.list', cpgList.list)
                                     .where('campaign_links.link', links.LinkId.OPEN)
                                     .as('campaign_links');
-                            }, 'campaign_links', 'campaign_links.subscription', subsTable + '.id');
+                            }, 'campaign_links.subscription', subsTable + '.id');
 
                         column = 'campaign_links.created';
 
@@ -93,7 +93,7 @@ async function run() {
                                     .where('campaign_links.list', cpgList.list)
                                     .where('campaign_links.link', links.LinkId.GENERAL_CLICK)
                                     .as('campaign_links');
-                            }, 'campaign_links', 'campaign_links.subscription', subsTable + '.id');
+                            }, 'campaign_links.subscription', subsTable + '.id');
 
                         column = 'campaign_links.created';
 


### PR DESCRIPTION
V2: TypeError: The operator "campaign_links.subscription" is not permitted
https://github.com/Mailtrain-org/mailtrain/issues/701

Successfully tested on the automation campaign triggered by the OPEN event.