### PR TITLE
decode possible encoded chunks in header

### DIFF
--- a/zone-mta/plugins/mailtrain-receiver.js
+++ b/zone-mta/plugins/mailtrain-receiver.js
@@ -13,7 +13,7 @@ module.exports.init = (app, done) => {
             envelope.dkim.keys = [];
         }
 
-        const dkimHeaderValue = headers.getFirst('x-mailtrain-dkim');
+        const dkimHeaderValue = require('libmime').decodeWords(headers.getFirst('x-mailtrain-dkim'));
 
         if (dkimHeaderValue) {
             const dkimKey = JSON.parse(dkimHeaderValue);


### PR DESCRIPTION
dkimKey expects JSON, however serveral times now, mailtrain started giving dkim header as encoded chunks. there is no try and catch on the json parse, so the emails won't be sent. 

require('libmime').decodeWords( header ) decodes chunks if present, or leaves the string alone - so even if the json is passed, it should not change the string.

i could not find the reason for the encoding so far