### PR TITLE
File cache fixes

### DIFF
--- a/server/lib/file-cache.js
+++ b/server/lib/file-cache.js
@@ -100,7 +100,7 @@ async function _fileCache(typeId, cacheConfig, keyGen) {
                     tmpName().then(tmp => {
                         tmpFilePath = tmp;
                         fileStream = fs.createWriteStream(tmpFilePath);
-                        setTimeout(callback, 5000);
+                        setTimeout(callback, 0);
                     })
                 } else {
                     callback();

--- a/server/lib/file-cache.js
+++ b/server/lib/file-cache.js
@@ -152,7 +152,7 @@ async function _fileCache(typeId, cacheConfig, keyGen) {
                     if (fileStream) {
                         fileStream.destroy(err);
                         fs.unlink(tmpFilePath, () => {
-                            knex('file_cache').where('type', typeId).where('key', key).del().then(()=> callback());
+                            callback();
                         });
                     } else {
                         callback();


### PR DESCRIPTION
1) Changed timeout from 5000 til 0 (ms) for `ensureFileStream()` fn, so uncached files don't wait 5 sec before they are delivered.

2) Removed deletion of cache-entries in the filestream destroy function so newly created entries are not removed